### PR TITLE
Input commitments v1 support

### DIFF
--- a/common/protob/messages-mintlayer.proto
+++ b/common/protob/messages-mintlayer.proto
@@ -87,8 +87,9 @@ message MintlayerSignTx {
     required uint32 outputs_count = 1;                         // number of transaction outputs
     required uint32 inputs_count = 2;                          // number of transaction inputs
     required MintlayerChainType chain_type = 3;                // Chain type to use
-    optional uint32 version = 4 [default=1];                   // transaction version
-    optional bool chunkify = 5;                                // display addresses in chunks of 4 characters
+    required uint32 input_commitments_version = 4;             // input commitments version
+    optional uint32 version = 5 [default=1];                   // transaction version
+    optional bool chunkify = 6;                                // display addresses in chunks of 4 characters
 }
 
 /**
@@ -113,7 +114,7 @@ message MintlayerTxRequest {
     * Request for additional data for a tx output
     */
     message MintlayerTxOutputRequest {
-        required uint32 output_index = 1;                      // index for the requested output
+        required uint32 output_index = 1;                     // index for the requested output
         optional bytes tx_hash = 2;                           // transaction hash for the specified output or none for the current transaction that is being signed
     }
     /**
@@ -237,8 +238,10 @@ message MintlayerFreezeOrder {
  */
 message MintlayerConcludeOrderV1 {
     required string order_id = 1;                        // order id in bech32 encoding
-    required MintlayerOutputValue filled_ask_amount = 2; // the already filled ask amount
-    required MintlayerOutputValue give_balance = 3;      // the remaining give balance of the order
+    required MintlayerOutputValue initially_asked = 2;   // the initial ask balance of the order
+    required MintlayerOutputValue initially_given = 3;   // the initial give balance of the order
+    required bytes ask_balance = 4;                      // the remaining ask balance of the order
+    required bytes give_balance = 5;                     // the remaining give balance of the order
 }
 
 /** Data type for account command Mint tokens
@@ -291,8 +294,10 @@ message MintlayerChangeTokenAuthority {
  */
 message MintlayerConcludeOrder {
     required string order_id = 1;                        // order id in bech32 encoding
-    required MintlayerOutputValue filled_ask_amount = 2; // the already filled ask amount
-    required MintlayerOutputValue give_balance = 3;      // the remaining give balance of the order
+    required MintlayerOutputValue initially_asked = 2;   // the initial ask balance of the order
+    required MintlayerOutputValue initially_given = 3;   // the initial give balance of the order
+    required bytes ask_balance = 4;                      // the remaining ask balance of the order
+    required bytes give_balance = 5;                     // the remaining give balance of the order
 }
 
 /** Data type for account command Fill order
@@ -302,8 +307,10 @@ message MintlayerFillOrder {
     required string order_id = 1;                        // order id in bech32 encoding
     required bytes amount = 2;                           // amount in atoms corresponds to the order's ask currency
     required string destination = 3;                     // the destination in bech32 encoding
-    required MintlayerOutputValue ask_balance = 4;       // the remaining ask balance of the order
-    required MintlayerOutputValue give_balance = 5;      // the remaining give balance of the order
+    required MintlayerOutputValue initially_asked = 4;   // the initial ask balance of the order
+    required MintlayerOutputValue initially_given = 5;   // the initial give balance of the order
+    required bytes ask_balance = 6;                      // the remaining ask balance of the order
+    required bytes give_balance = 7;                     // the remaining give balance of the order
 }
 
 /** Data type for account command Change token metadata uri
@@ -491,11 +498,11 @@ message MintlayerTxAck {
      * @next MintlayerTxRequest
      */
     message MintlayerTxInput {
-      optional MintlayerUtxoTxInput utxo = 1;                       // UTXO input
-      optional MintlayerAccountTxInput account = 2;                 // account spending input
-      optional MintlayerAccountCommandTxInput account_command = 3;  // account command input
-      optional MintlayerOrderCommandTxInput order_command = 4;      // order command input
-  }
+        optional MintlayerUtxoTxInput utxo = 1;                       // UTXO input
+        optional MintlayerAccountTxInput account = 2;                 // account spending input
+        optional MintlayerAccountCommandTxInput account_command = 3;  // account command input
+        optional MintlayerOrderCommandTxInput order_command = 4;      // order command input
+    }
 
     /**
      * Request: Data about output to be signed.
@@ -503,18 +510,17 @@ message MintlayerTxAck {
      * @next MintlayerTxRequest
      */
     message MintlayerTxOutput {
-      optional MintlayerTransferTxOutput transfer = 1;                                 // transfer output
-      optional MintlayerLockThenTransferTxOutput lock_then_transfer = 2;               // lock then transfer output
-      optional MintlayerBurnTxOutput burn = 3;                                         // burn output
-      optional MintlayerCreateStakePoolTxOutput create_stake_pool = 4;                 // create stake pool output
-      optional MintlayerProduceBlockFromStakeTxOutput produce_block_from_stake = 5;    // create block from stake output
-      optional MintlayerCreateDelegationIdTxOutput create_delegation_id = 6;           // create delegation Id output
-      optional MintlayerDelegateStakingTxOutput delegate_staking = 7;                  // delegate staking output
-      optional MintlayerIssueFungibleTokenTxOutput issue_fungible_token = 8;           // issue fungible token output
-      optional MintlayerIssueNftTxOutput issue_nft = 9;                                // issue NFT output
-      optional MintlayerDataDepositTxOutput data_deposit = 10;                         // data deposit output
-      optional MintlayerHtlcTxOutput htlc = 11;                                        // HTLC output
-      optional MintlayerCreateOrderTxOutput create_order = 12;                         // Create order output
-  }
+        optional MintlayerTransferTxOutput transfer = 1;                                 // transfer output
+        optional MintlayerLockThenTransferTxOutput lock_then_transfer = 2;               // lock then transfer output
+        optional MintlayerBurnTxOutput burn = 3;                                         // burn output
+        optional MintlayerCreateStakePoolTxOutput create_stake_pool = 4;                 // create stake pool output
+        optional MintlayerProduceBlockFromStakeTxOutput produce_block_from_stake = 5;    // create block from stake output
+        optional MintlayerCreateDelegationIdTxOutput create_delegation_id = 6;           // create delegation Id output
+        optional MintlayerDelegateStakingTxOutput delegate_staking = 7;                  // delegate staking output
+        optional MintlayerIssueFungibleTokenTxOutput issue_fungible_token = 8;           // issue fungible token output
+        optional MintlayerIssueNftTxOutput issue_nft = 9;                                // issue NFT output
+        optional MintlayerDataDepositTxOutput data_deposit = 10;                         // data deposit output
+        optional MintlayerHtlcTxOutput htlc = 11;                                        // HTLC output
+        optional MintlayerCreateOrderTxOutput create_order = 12;                         // Create order output
+    }
 }
-

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -89,6 +89,7 @@ SOURCE_MOD += [
     'embed/upymod/modtrezorcrypto/modtrezorcrypto.c',
     'embed/upymod/modtrezorcrypto/rand.c',
     'embed/upymod/modtrezormintlayer/modtrezormintlayer.c',
+    'embed/upymod/modtrezormintlayer/utils.c',
 ]
 SOURCE_MOD_CRYPTO += [
     'vendor/trezor-crypto/address.c',

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -86,6 +86,7 @@ SOURCE_MOD += [
     'embed/upymod/modtrezorcrypto/crc.c',
     'embed/upymod/modtrezorcrypto/modtrezorcrypto.c',
     'embed/upymod/modtrezormintlayer/modtrezormintlayer.c',
+    'embed/upymod/modtrezormintlayer/utils.c',
 ]
 SOURCE_MOD_CRYPTO += [
     'vendor/trezor-crypto/address.c',

--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.61",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -57,9 +57,9 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -97,6 +97,26 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -166,13 +186,13 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -275,7 +295,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -298,26 +318,28 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.12"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.12"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -331,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -344,9 +366,9 @@ version = "1.8.0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -400,22 +422,22 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.61",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -475,7 +497,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.61",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -491,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.61"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -520,7 +542,7 @@ dependencies = [
 [[package]]
 name = "trezor-common"
 version = "1.0.2"
-source = "git+https://github.com/mintlayer/mintlayer-core?branch=master#6301aa6fe50647a8c9ce422c16d85f2571c5a234"
+source = "git+https://github.com/mintlayer/mintlayer-core?rev=563511e331fd2d619f2699612863df9ecee58ff8#563511e331fd2d619f2699612863df9ecee58ff8"
 dependencies = [
  "num-derive 0.4.2",
  "num-traits",
@@ -590,6 +612,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsize"

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -100,7 +100,11 @@ parity-scale-codec = { version = "3.1", default-features = false, features = [
     "derive",
     "chain-error",
 ], optional = true }
-ml_common = { git = "https://github.com/mintlayer/mintlayer-core", package = "trezor-common", branch = "master", optional = true }
+[dependencies.ml_common]
+git = "https://github.com/mintlayer/mintlayer-core"
+rev = "563511e331fd2d619f2699612863df9ecee58ff8" # Commit "Sighash input commitments v1"
+package = "trezor-common"
+optional = true
 
 # Runtime dependencies
 

--- a/core/embed/rust/mintlayer.h
+++ b/core/embed/rust/mintlayer.h
@@ -1,3 +1,6 @@
+#ifndef MINTLAYER_H
+#define MINTLAYER_H
+
 #include "common.h"
 
 uint32_t mintlayer_screen_fatal_error_rust(const char* title, const char* msg,
@@ -142,3 +145,36 @@ ByteArray mintlayer_encode_create_order_output(
     uint32_t give_token_id_data_len);
 
 ByteArray mintlayer_encode_compact_length(uint32_t length);
+
+ByteArray mintlayer_encode_empty_input_commitment();
+
+ByteArray mintlayer_encode_input_commitment_for_utxo(
+    const unsigned char* encoded_utxo_data, uint32_t encoded_utxo_data_len);
+
+ByteArray
+mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo(
+    const unsigned char* encoded_utxo_data, uint32_t encoded_utxo_data_len,
+    const unsigned char* staker_balance_amount_data,
+    uint32_t staker_balance_amount_data_len);
+
+ByteArray mintlayer_encode_input_commitment_v1_for_fill_order(
+    const unsigned char* asked_token_data, uint32_t asked_token_data_len,
+    const unsigned char* initially_asked_amount_data,
+    uint32_t initially_asked_amount_data_len,
+    const unsigned char* given_token_data, uint32_t given_token_data_len,
+    const unsigned char* initially_given_amount_data,
+    uint32_t initially_given_amount_data_len);
+
+ByteArray mintlayer_encode_input_commitment_v1_for_conclude_order(
+    const unsigned char* asked_token_data, uint32_t asked_token_data_len,
+    const unsigned char* initially_asked_amount_data,
+    uint32_t initially_asked_amount_data_len,
+    const unsigned char* ask_balance_amount_data,
+    uint32_t ask_balance_amount_data_len, const unsigned char* given_token_data,
+    uint32_t given_token_data_len,
+    const unsigned char* initially_given_amount_data,
+    uint32_t initially_given_amount_data_len,
+    const unsigned char* give_balance_amount_data,
+    uint32_t give_balance_amount_data_len);
+
+#endif  // MINTLAYER_H

--- a/core/embed/rust/src/mintlayer/input_commitments.rs
+++ b/core/embed/rust/src/mintlayer/input_commitments.rs
@@ -1,0 +1,214 @@
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    ptr::null_mut,
+};
+
+use ml_common::{
+    AccountCommand, AccountCommandTag, AccountOutPoint, AccountSpending, Amount, Destination,
+    HashedTimelockContract, HtlcSecretHash, IsTokenFreezable, IsTokenUnfreezable, Metadata,
+    NftIssuance, NftIssuanceV0, OrderAccountCommand, OrderData, OutPointSourceId,
+    OutPointSourceIdTag, OutputTimeLock, OutputTimeLockTag, OutputValue, PublicKey,
+    PublicKeyHolder, SighashInputCommitment, StakePoolData, TokenIssuance, TokenIssuanceV1,
+    TokenTotalSupply, TokenTotalSupplyTag, TxInput, TxOutput, UtxoOutPoint, VRFPublicKeyHolder,
+    H256,
+};
+use num_traits::FromPrimitive;
+use parity_scale_codec::{DecodeAll, Encode};
+
+use crate::{
+    micropython::ffi,
+    mintlayer::{
+        encode_to_byte_array, handle_err_or_encode, parse_amount, parse_output_value,
+        parse_output_value_raw, ByteArray, MintlayerErrorCode,
+    },
+};
+
+#[no_mangle]
+extern "C" fn mintlayer_encode_empty_input_commitment() -> ByteArray {
+    encode_to_byte_array(&SighashInputCommitment::None)
+}
+
+#[no_mangle]
+extern "C" fn mintlayer_encode_input_commitment_for_utxo(
+    encoded_utxo_data: *const u8,
+    encoded_utxo_data_len: u32,
+) -> ByteArray {
+    let encoded_utxo =
+        unsafe { core::slice::from_raw_parts(encoded_utxo_data, encoded_utxo_data_len as usize) };
+    let res = mintlayer_encode_input_commitment_for_utxo_impl(encoded_utxo);
+    handle_err_or_encode(res)
+}
+
+fn mintlayer_encode_input_commitment_for_utxo_impl(
+    encoded_utxo: &[u8],
+) -> Result<SighashInputCommitment, MintlayerErrorCode> {
+    let utxo = TxOutput::decode_all(&mut &encoded_utxo[..])
+        .map_err(|_| MintlayerErrorCode::InvalidEncodedUtxo)?;
+
+    Ok(SighashInputCommitment::Utxo(utxo))
+}
+
+#[no_mangle]
+extern "C" fn mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo(
+    encoded_utxo_data: *const u8,
+    encoded_utxo_data_len: u32,
+    staker_balance_amount_data: *const u8,
+    staker_balance_amount_data_len: u32,
+) -> ByteArray {
+    let encoded_utxo =
+        unsafe { core::slice::from_raw_parts(encoded_utxo_data, encoded_utxo_data_len as usize) };
+    let staker_balance_amount = unsafe {
+        core::slice::from_raw_parts(
+            staker_balance_amount_data,
+            staker_balance_amount_data_len as usize,
+        )
+    };
+    let res = mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo_impl(
+        encoded_utxo,
+        staker_balance_amount,
+    );
+    handle_err_or_encode(res)
+}
+
+fn mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo_impl(
+    encoded_utxo: &[u8],
+    staker_balance_amount: &[u8],
+) -> Result<SighashInputCommitment, MintlayerErrorCode> {
+    let utxo = TxOutput::decode_all(&mut &encoded_utxo[..])
+        .map_err(|_| MintlayerErrorCode::InvalidEncodedUtxo)?;
+    let staker_balance = Amount::from_bytes_be(staker_balance_amount.as_ref())
+        .ok_or(MintlayerErrorCode::InvalidAmount)?;
+
+    Ok(SighashInputCommitment::ProduceBlockFromStakeUtxo {
+        utxo,
+        staker_balance,
+    })
+}
+
+#[no_mangle]
+extern "C" fn mintlayer_encode_input_commitment_v1_for_fill_order(
+    asked_token_data: *const u8,
+    asked_token_data_len: u32,
+    initially_asked_amount_data: *const u8,
+    initially_asked_amount_data_len: u32,
+    given_token_data: *const u8,
+    given_token_data_len: u32,
+    initially_given_amount_data: *const u8,
+    initially_given_amount_data_len: u32,
+) -> ByteArray {
+    let asked_token =
+        unsafe { core::slice::from_raw_parts(asked_token_data, asked_token_data_len as usize) };
+    let initially_asked_amount = unsafe {
+        core::slice::from_raw_parts(
+            initially_asked_amount_data,
+            initially_asked_amount_data_len as usize,
+        )
+    };
+    let given_token =
+        unsafe { core::slice::from_raw_parts(given_token_data, given_token_data_len as usize) };
+    let initially_given_amount = unsafe {
+        core::slice::from_raw_parts(
+            initially_given_amount_data,
+            initially_given_amount_data_len as usize,
+        )
+    };
+
+    let res = mintlayer_encode_input_commitment_v1_for_fill_order_impl(
+        asked_token,
+        initially_asked_amount,
+        given_token,
+        initially_given_amount,
+    );
+    handle_err_or_encode(res)
+}
+
+fn mintlayer_encode_input_commitment_v1_for_fill_order_impl(
+    asked_token: &[u8],
+    initially_asked_amount: &[u8],
+    given_token: &[u8],
+    initially_given_amount: &[u8],
+) -> Result<SighashInputCommitment, MintlayerErrorCode> {
+    let initially_asked = parse_output_value(initially_asked_amount, asked_token)?;
+    let initially_given = parse_output_value(initially_given_amount, given_token)?;
+
+    Ok(SighashInputCommitment::FillOrderAccountCommand {
+        initially_asked,
+        initially_given,
+    })
+}
+
+#[no_mangle]
+extern "C" fn mintlayer_encode_input_commitment_v1_for_conclude_order(
+    asked_token_data: *const u8,
+    asked_token_data_len: u32,
+    initially_asked_amount_data: *const u8,
+    initially_asked_amount_data_len: u32,
+    ask_balance_amount_data: *const u8,
+    ask_balance_amount_data_len: u32,
+    given_token_data: *const u8,
+    given_token_data_len: u32,
+    initially_given_amount_data: *const u8,
+    initially_given_amount_data_len: u32,
+    give_balance_amount_data: *const u8,
+    give_balance_amount_data_len: u32,
+) -> ByteArray {
+    let asked_token =
+        unsafe { core::slice::from_raw_parts(asked_token_data, asked_token_data_len as usize) };
+    let initially_asked_amount = unsafe {
+        core::slice::from_raw_parts(
+            initially_asked_amount_data,
+            initially_asked_amount_data_len as usize,
+        )
+    };
+    let ask_balance_amount = unsafe {
+        core::slice::from_raw_parts(
+            ask_balance_amount_data,
+            ask_balance_amount_data_len as usize,
+        )
+    };
+    let given_token =
+        unsafe { core::slice::from_raw_parts(given_token_data, given_token_data_len as usize) };
+    let initially_given_amount = unsafe {
+        core::slice::from_raw_parts(
+            initially_given_amount_data,
+            initially_given_amount_data_len as usize,
+        )
+    };
+    let give_balance_amount = unsafe {
+        core::slice::from_raw_parts(
+            give_balance_amount_data,
+            give_balance_amount_data_len as usize,
+        )
+    };
+
+    let res = mintlayer_encode_input_commitment_v1_for_conclude_order_impl(
+        asked_token,
+        initially_asked_amount,
+        ask_balance_amount,
+        given_token,
+        initially_given_amount,
+        give_balance_amount,
+    );
+    handle_err_or_encode(res)
+}
+
+fn mintlayer_encode_input_commitment_v1_for_conclude_order_impl(
+    asked_token: &[u8],
+    initially_asked_amount: &[u8],
+    ask_balance_amount: &[u8],
+    given_token: &[u8],
+    initially_given_amount: &[u8],
+    give_balance_amount: &[u8],
+) -> Result<SighashInputCommitment, MintlayerErrorCode> {
+    let initially_asked = parse_output_value(initially_asked_amount, asked_token)?;
+    let initially_given = parse_output_value(initially_given_amount, given_token)?;
+    let ask_balance = parse_amount(ask_balance_amount)?;
+    let give_balance = parse_amount(give_balance_amount)?;
+
+    Ok(SighashInputCommitment::ConcludeOrderAccountCommand {
+        initially_asked,
+        initially_given,
+        ask_balance,
+        give_balance,
+    })
+}

--- a/core/embed/rust/src/mintlayer/mod.rs
+++ b/core/embed/rust/src/mintlayer/mod.rs
@@ -15,6 +15,8 @@ use ml_common::{
 use num_traits::FromPrimitive;
 use parity_scale_codec::{DecodeAll, Encode};
 
+pub mod input_commitments;
+
 #[repr(C)]
 #[derive(Eq, PartialEq, Clone, Copy)]
 pub enum MintlayerErrorCode {
@@ -29,6 +31,7 @@ pub enum MintlayerErrorCode {
     InvalidPublicKey = 9,
     InvalidOutputTimeLock = 10,
     InvalidTokenTotalSupply = 11,
+    InvalidEncodedUtxo = 12,
 }
 
 #[repr(C)]
@@ -110,8 +113,7 @@ fn mintlayer_encode_account_spending_input_impl(
             .try_into()
             .map_err(|_| MintlayerErrorCode::WrongHashSize)?,
     );
-    let amount =
-        Amount::from_bytes_be(coin_amount.as_ref()).ok_or(MintlayerErrorCode::InvalidAmount)?;
+    let amount = parse_amount(coin_amount)?;
     let tx_input = TxInput::Account(AccountOutPoint {
         nonce,
         account: AccountSpending::DelegationBalance(delegation_id, amount),
@@ -150,8 +152,7 @@ fn mintlayer_encode_token_account_command_input_impl(
         .ok_or(MintlayerErrorCode::InvalidAccountCommand)?
     {
         AccountCommandTag::MintTokens => {
-            let amount =
-                Amount::from_bytes_be(data.as_ref()).ok_or(MintlayerErrorCode::InvalidAmount)?;
+            let amount = parse_amount(data)?;
             AccountCommand::MintTokens(token_id, amount)
         }
         AccountCommandTag::UnmintTokens => AccountCommand::UnmintTokens(token_id),
@@ -170,7 +171,9 @@ fn mintlayer_encode_token_account_command_input_impl(
         AccountCommandTag::ChangeTokenMetadataUri => {
             AccountCommand::ChangeTokenMetadataUri(token_id, data.to_vec())
         }
-        _ => return Err(MintlayerErrorCode::InvalidAccountCommand),
+        AccountCommandTag::ConcludeOrder | AccountCommandTag::FillOrder => {
+            return Err(MintlayerErrorCode::InvalidAccountCommand)
+        }
     };
     let tx_input = TxInput::AccountCommand(nonce, account_command);
     Ok(tx_input)
@@ -268,8 +271,7 @@ fn mintlayer_encode_fill_order_account_command_input_impl(
             .try_into()
             .map_err(|_| MintlayerErrorCode::WrongHashSize)?,
     );
-    let amount =
-        Amount::from_bytes_be(coin_amount.as_ref()).ok_or(MintlayerErrorCode::InvalidAmount)?;
+    let amount = parse_amount(coin_amount)?;
 
     let destination = Destination::decode_all(&mut destination_bytes.as_ref())
         .map_err(|_| MintlayerErrorCode::InvalidDestination)?;
@@ -312,8 +314,7 @@ fn mintlayer_encode_fill_order_v1_order_command_input_impl(
             .try_into()
             .map_err(|_| MintlayerErrorCode::WrongHashSize)?,
     );
-    let amount =
-        Amount::from_bytes_be(coin_amount.as_ref()).ok_or(MintlayerErrorCode::InvalidAmount)?;
+    let amount = parse_amount(coin_amount)?;
 
     let destination = Destination::decode_all(&mut destination_bytes.as_ref())
         .map_err(|_| MintlayerErrorCode::InvalidDestination)?;
@@ -322,29 +323,39 @@ fn mintlayer_encode_fill_order_v1_order_command_input_impl(
     Ok(tx_input)
 }
 
+fn parse_amount(amount_data: &[u8]) -> Result<Amount, MintlayerErrorCode> {
+    Amount::from_bytes_be(amount_data).ok_or(MintlayerErrorCode::InvalidAmount)
+}
+
 fn parse_output_value(
-    amount_data: *const u8,
-    amount_data_len: u32,
-    token_id_data_len: u32,
-    token_id_data: *const u8,
-) -> Result<OutputValue, ByteArray> {
-    let coin_amount = unsafe { core::slice::from_raw_parts(amount_data, amount_data_len as usize) };
-    let amount = match Amount::from_bytes_be(coin_amount.as_ref()) {
-        Some(amount) => amount,
-        None => return Err(MintlayerErrorCode::InvalidAmount.into()),
-    };
-    let value = if token_id_data_len == 32 {
-        let token_id =
-            unsafe { core::slice::from_raw_parts(token_id_data, token_id_data_len as usize) };
-        let token_id = H256(match token_id.try_into() {
-            Ok(hash) => hash,
-            Err(_) => return Err(MintlayerErrorCode::WrongHashSize.into()),
-        });
+    amount_data: &[u8],
+    token_id_data: &[u8],
+) -> Result<OutputValue, MintlayerErrorCode> {
+    let amount = parse_amount(amount_data)?;
+
+    let value = if !token_id_data.is_empty() {
+        let token_id = H256(
+            token_id_data
+                .try_into()
+                .map_err(|_| MintlayerErrorCode::WrongHashSize)?,
+        );
         OutputValue::TokenV1(token_id, amount)
     } else {
         OutputValue::Coin(amount)
     };
     Ok(value)
+}
+
+fn parse_output_value_raw(
+    amount_data: *const u8,
+    amount_data_len: u32,
+    token_id_data_len: u32,
+    token_id_data: *const u8,
+) -> Result<OutputValue, ByteArray> {
+    let amount = unsafe { core::slice::from_raw_parts(amount_data, amount_data_len as usize) };
+    let token_id =
+        unsafe { core::slice::from_raw_parts(token_id_data, token_id_data_len as usize) };
+    parse_output_value(amount, token_id).map_err(|err| err.into())
 }
 
 #[no_mangle]
@@ -356,7 +367,7 @@ extern "C" fn mintlayer_encode_transfer_output(
     destination_data: *const u8,
     destination_data_len: u32,
 ) -> ByteArray {
-    let value = match parse_output_value(
+    let value = match parse_output_value_raw(
         amount_data,
         amount_data_len,
         token_id_data_len,
@@ -389,7 +400,7 @@ extern "C" fn mintlayer_encode_lock_then_transfer_output(
     destination_data: *const u8,
     destination_data_len: u32,
 ) -> ByteArray {
-    let value = match parse_output_value(
+    let value = match parse_output_value_raw(
         amount_data,
         amount_data_len,
         token_id_data_len,
@@ -425,7 +436,7 @@ extern "C" fn mintlayer_encode_burn_output(
     token_id_data: *const u8,
     token_id_data_len: u32,
 ) -> ByteArray {
-    let value = match parse_output_value(
+    let value = match parse_output_value_raw(
         amount_data,
         amount_data_len,
         token_id_data_len,
@@ -508,16 +519,14 @@ fn mintlayer_encode_create_stake_pool_output_impl(
             .try_into()
             .map_err(|_| MintlayerErrorCode::WrongHashSize)?,
     );
-    let pledge = Amount::from_bytes_be(pledge_coin_amount.as_ref())
-        .ok_or(MintlayerErrorCode::InvalidAmount)?;
+    let pledge = parse_amount(pledge_coin_amount)?;
     let staker = Destination::decode_all(&mut staker_destination_bytes.as_ref())
         .map_err(|_| MintlayerErrorCode::InvalidDestination)?;
     let vrf_public_key = VRFPublicKeyHolder::decode_all(&mut vrf_public_key.as_ref())
         .map_err(|_| MintlayerErrorCode::InvalidVrfPublicKey)?;
     let decommission_key = Destination::decode_all(&mut decommission_destination_bytes.as_ref())
         .map_err(|_| MintlayerErrorCode::InvalidDestination)?;
-    let cost_per_block = Amount::from_bytes_be(cost_per_block_coin_amount.as_ref())
-        .ok_or(MintlayerErrorCode::InvalidAmount)?;
+    let cost_per_block = parse_amount(cost_per_block_coin_amount)?;
     let txo = TxOutput::CreateStakePool(
         pool_id,
         StakePoolData {
@@ -590,9 +599,9 @@ extern "C" fn mintlayer_encode_delegate_staking_output(
     delegation_id_data_len: u32,
 ) -> ByteArray {
     let coin_amount = unsafe { core::slice::from_raw_parts(amount_data, amount_data_len as usize) };
-    let amount = match Amount::from_bytes_be(coin_amount.as_ref()) {
-        Some(amount) => amount,
-        None => return MintlayerErrorCode::InvalidAmount.into(),
+    let amount = match parse_amount(coin_amount) {
+        Ok(amount) => amount,
+        Err(err) => return err.into(),
     };
 
     let delegation_id =
@@ -662,8 +671,7 @@ fn mintlayer_encode_issue_fungible_token_output_impl(
         .ok_or(MintlayerErrorCode::InvalidTokenTotalSupply)?
     {
         TokenTotalSupplyTag::Fixed => {
-            let amount = Amount::from_bytes_be(coin_amount.as_ref())
-                .ok_or(MintlayerErrorCode::InvalidAmount)?;
+            let amount = parse_amount(coin_amount)?;
             TokenTotalSupply::Fixed(amount)
         }
         TokenTotalSupplyTag::Lockable => TokenTotalSupply::Lockable,
@@ -823,7 +831,7 @@ extern "C" fn mintlayer_encode_htlc_output(
     secret_hash_data: *const u8,
     secret_hash_data_len: u32,
 ) -> ByteArray {
-    let value = match parse_output_value(
+    let value = match parse_output_value_raw(
         amount_data,
         amount_data_len,
         token_id_data_len,
@@ -906,7 +914,7 @@ extern "C" fn mintlayer_encode_create_order_output(
     give_token_id_data: *const u8,
     give_token_id_data_len: u32,
 ) -> ByteArray {
-    let ask_value = match parse_output_value(
+    let ask_value = match parse_output_value_raw(
         ask_amount_data,
         ask_amount_data_len,
         ask_token_id_data_len,
@@ -916,7 +924,7 @@ extern "C" fn mintlayer_encode_create_order_output(
         Err(value) => return value,
     };
 
-    let give_value = match parse_output_value(
+    let give_value = match parse_output_value_raw(
         give_amount_data,
         give_amount_data_len,
         give_token_id_data_len,

--- a/core/embed/upymod/modtrezormintlayer/modtrezormintlayer-input-comm.h
+++ b/core/embed/upymod/modtrezormintlayer/modtrezormintlayer-input-comm.h
@@ -1,0 +1,159 @@
+#include <stdio.h>
+#include "py/objstr.h"
+
+#include "embed/upymod/trezorobj.h"
+
+#include "embed/rust/mintlayer.h"
+
+#include "bip32.h"
+#include "bip39.h"
+#include "curves.h"
+#include "memzero.h"
+
+#include "utils.h"
+
+/// def encode_empty_input_commitment() -> bytes:
+///     """
+///     Encodes an empty input commitment.
+///     """
+STATIC mp_obj_t
+mod_trezormintlayer_utils_mintlayer_encode_empty_input_commitment() {
+  ByteArray arr = mintlayer_encode_empty_input_commitment();
+  handle_err(&arr);
+
+  return mp_obj_new_bytes(arr.data, arr.len_or_err.len);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(
+    mod_trezormintlayer_utils_mintlayer_encode_empty_input_commitment_obj,
+    mod_trezormintlayer_utils_mintlayer_encode_empty_input_commitment);
+
+/// def encode_input_commitment_for_utxo(encoded_utxo: bytes) -> bytes:
+///     """
+///     Encodes an input commitment for a utxo.
+//      Note: in input commitments v0 this works for any utxo input;
+///     in v1 it works for any utxo input except ProduceBlockFromStake.
+///     """
+STATIC mp_obj_t
+mod_trezormintlayer_utils_mintlayer_encode_input_commitment_for_utxo(
+    mp_obj_t encoded_utxo_obj) {
+  mp_buffer_info_t encoded_utxo = {0};
+  mp_get_buffer_raise(encoded_utxo_obj, &encoded_utxo, MP_BUFFER_READ);
+  ByteArray arr = mintlayer_encode_input_commitment_for_utxo(encoded_utxo.buf,
+                                                             encoded_utxo.len);
+  handle_err(&arr);
+
+  return mp_obj_new_bytes(arr.data, arr.len_or_err.len);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_for_utxo_obj,
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_for_utxo);
+
+/// def encode_input_commitment_v1_for_produce_block_from_stake_utxo(
+///   encoded_utxo: bytes, staker_balance_amount: bytes
+/// ) -> bytes:
+///     """
+///     Encodes an input commitment for a ProduceBlockFromStake utxo (v1 only).
+///     """
+STATIC mp_obj_t
+mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo(
+    mp_obj_t encoded_utxo_obj, mp_obj_t staker_balance_amount_obj) {
+  mp_buffer_info_t encoded_utxo = {0};
+  mp_get_buffer_raise(encoded_utxo_obj, &encoded_utxo, MP_BUFFER_READ);
+  mp_buffer_info_t staker_balance_amount = {0};
+  mp_get_buffer_raise(staker_balance_amount_obj, &staker_balance_amount,
+                      MP_BUFFER_READ);
+  ByteArray arr =
+      mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo(
+          encoded_utxo.buf, encoded_utxo.len, staker_balance_amount.buf,
+          staker_balance_amount.len);
+  handle_err(&arr);
+
+  return mp_obj_new_bytes(arr.data, arr.len_or_err.len);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo_obj,
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo);
+
+/// def encode_input_commitment_v1_for_fill_order(
+///     asked_token: bytes, initially_asked_amount: bytes,
+///     given_token: bytes, initially_given_amount: bytes,
+/// ) -> bytes:
+///     """
+///     Encodes input commitment for filling an order (v1 only);
+///     asked_token and given_token can be empty byte arrays, which means that
+///     the corresponding
+//      amounts are in coins.
+///     """
+STATIC mp_obj_t
+mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_fill_order(
+    size_t n_args, const mp_obj_t *args) {
+  mp_buffer_info_t asked_token = {0};
+  mp_get_buffer_raise(args[0], &asked_token, MP_BUFFER_READ);
+  mp_buffer_info_t initially_asked_amount = {0};
+  mp_get_buffer_raise(args[1], &initially_asked_amount, MP_BUFFER_READ);
+
+  mp_buffer_info_t given_token = {0};
+  mp_get_buffer_raise(args[2], &given_token, MP_BUFFER_READ);
+  mp_buffer_info_t initially_given_amount = {0};
+  mp_get_buffer_raise(args[3], &initially_given_amount, MP_BUFFER_READ);
+
+  ByteArray arr = mintlayer_encode_input_commitment_v1_for_fill_order(
+      asked_token.buf, asked_token.len, initially_asked_amount.buf,
+      initially_asked_amount.len, given_token.buf, given_token.len,
+      initially_given_amount.buf, initially_given_amount.len);
+  handle_err(&arr);
+
+  return mp_obj_new_bytes(arr.data, arr.len_or_err.len);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_fill_order_obj,
+    4, 4,
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_fill_order);
+
+/// def encode_input_commitment_v1_for_conclude_order(
+///     asked_token: bytes, initially_asked_amount: bytes, ask_balance_amount:
+///     bytes, given_token: bytes, initially_given_amount: bytes,
+///     give_balance_amount: bytes
+/// ) -> bytes:
+///     """
+///     Encodes input commitment for concluding an order (v1 only);
+///     asked_token and given_token can be empty byte arrays, which means that
+///     the corresponding
+//      amounts are in coins.
+///     """
+STATIC mp_obj_t
+mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_conclude_order(
+    size_t n_args, const mp_obj_t *args) {
+  mp_buffer_info_t asked_token = {0};
+  mp_get_buffer_raise(args[0], &asked_token, MP_BUFFER_READ);
+  mp_buffer_info_t initially_asked_amount = {0};
+  mp_get_buffer_raise(args[1], &initially_asked_amount, MP_BUFFER_READ);
+  mp_buffer_info_t ask_balance_amount = {0};
+  mp_get_buffer_raise(args[2], &ask_balance_amount, MP_BUFFER_READ);
+
+  mp_buffer_info_t given_token = {0};
+  mp_get_buffer_raise(args[3], &given_token, MP_BUFFER_READ);
+  mp_buffer_info_t initially_given_amount = {0};
+  mp_get_buffer_raise(args[4], &initially_given_amount, MP_BUFFER_READ);
+  mp_buffer_info_t give_balance_amount = {0};
+  mp_get_buffer_raise(args[5], &give_balance_amount, MP_BUFFER_READ);
+
+  ByteArray arr = mintlayer_encode_input_commitment_v1_for_conclude_order(
+      asked_token.buf, asked_token.len, initially_asked_amount.buf,
+      initially_asked_amount.len, ask_balance_amount.buf,
+      ask_balance_amount.len, given_token.buf, given_token.len,
+      initially_given_amount.buf, initially_given_amount.len,
+      give_balance_amount.buf, give_balance_amount.len);
+  handle_err(&arr);
+
+  return mp_obj_new_bytes(arr.data, arr.len_or_err.len);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_conclude_order_obj,
+    6, 6,
+    mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_conclude_order);

--- a/core/embed/upymod/modtrezormintlayer/modtrezormintlayer.c
+++ b/core/embed/upymod/modtrezormintlayer/modtrezormintlayer.c
@@ -27,52 +27,8 @@
 
 // #if MICROPY_PY_TREZORMINTLAYER
 
+#include "modtrezormintlayer-input-comm.h"
 #include "modtrezormintlayer.h"
-
-void handle_err(ByteArray *res) {
-  if (res->data != NULL) {
-    return;
-  }
-
-  switch (res->len_or_err.err) {
-    case WrongHashSize:
-      mp_raise_ValueError("Invalid hash size");
-      break;
-    case InvalidUtxoType:
-      mp_raise_ValueError("Invalid UTXO type");
-      break;
-    case InvalidAmount:
-      mp_raise_ValueError("Invalid amount");
-      break;
-    case InvalidAccountCommand:
-      mp_raise_ValueError("Invalid account command");
-      break;
-    case InvalidDestination:
-      mp_raise_ValueError("Invalid destination");
-      break;
-    case InvalidIsTokenUnfreezable:
-      mp_raise_ValueError("Invalid token unfreezable flag");
-      break;
-    case InvalidIsTokenFreezable:
-      mp_raise_ValueError("Invalid token freezable flag");
-      break;
-    case InvalidVrfPublicKey:
-      mp_raise_ValueError("Invalid VRF public key");
-      break;
-    case InvalidPublicKey:
-      mp_raise_ValueError("Invalid public key");
-      break;
-    case InvalidOutputTimeLock:
-      mp_raise_ValueError("Invalid output time lock");
-      break;
-    case InvalidTokenTotalSupply:
-      mp_raise_ValueError("Invalid token total supply");
-      break;
-    default:
-      mp_raise_ValueError("Unknown error");
-      break;
-  }
-}
 
 STATIC const mp_rom_map_elem_t mod_trezormintlayer_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_trezormintlayer)},
@@ -135,6 +91,24 @@ STATIC const mp_rom_map_elem_t mod_trezormintlayer_globals_table[] = {
          &mod_trezormintlayer_utils_mintlayer_encode_create_order_output_obj)},
     {MP_ROM_QSTR(MP_QSTR_encode_compact_length),
      MP_ROM_PTR(&mod_trezormintlayer_utils_mintlayer_encode_comact_length_obj)},
+
+    // Input commitments
+    {MP_ROM_QSTR(MP_QSTR_encode_empty_input_commitment),
+     MP_ROM_PTR(
+         &mod_trezormintlayer_utils_mintlayer_encode_empty_input_commitment_obj)},
+    {MP_ROM_QSTR(MP_QSTR_encode_input_commitment_for_utxo),
+     MP_ROM_PTR(
+         &mod_trezormintlayer_utils_mintlayer_encode_input_commitment_for_utxo_obj)},
+    {MP_ROM_QSTR(
+         MP_QSTR_encode_input_commitment_v1_for_produce_block_from_stake_utxo),
+     MP_ROM_PTR(
+         &mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_produce_block_from_stake_utxo_obj)},
+    {MP_ROM_QSTR(MP_QSTR_encode_input_commitment_v1_for_fill_order),
+     MP_ROM_PTR(
+         &mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_fill_order_obj)},
+    {MP_ROM_QSTR(MP_QSTR_encode_input_commitment_v1_for_conclude_order),
+     MP_ROM_PTR(
+         &mod_trezormintlayer_utils_mintlayer_encode_input_commitment_v1_for_conclude_order_obj)},
 };
 STATIC MP_DEFINE_CONST_DICT(mod_trezormintlayer_globals,
                             mod_trezormintlayer_globals_table);

--- a/core/embed/upymod/modtrezormintlayer/modtrezormintlayer.h
+++ b/core/embed/upymod/modtrezormintlayer/modtrezormintlayer.h
@@ -10,7 +10,7 @@
 #include "curves.h"
 #include "memzero.h"
 
-void handle_err(ByteArray *res);
+#include "utils.h"
 
 /// def encode_utxo_input(tx_hash: bytes, index: int, utxo_type: int) -> bytes:
 ///     """
@@ -115,7 +115,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(
 /// amount: bytes, destination: bytes)
 /// -> bytes:
 ///     """
-///     encodes an fill order account command from the nonce, order id, output
+///     encodes a fill order account command from the nonce, order id, output
 ///     amount and destination
 ///     """
 STATIC mp_obj_t

--- a/core/embed/upymod/modtrezormintlayer/utils.c
+++ b/core/embed/upymod/modtrezormintlayer/utils.c
@@ -1,0 +1,48 @@
+#include "py/runtime.h"
+
+#include "utils.h"
+
+void handle_err(ByteArray *res) {
+  if (res->data != NULL) {
+    return;
+  }
+
+  switch (res->len_or_err.err) {
+    case WrongHashSize:
+      mp_raise_ValueError("Invalid hash size");
+      break;
+    case InvalidUtxoType:
+      mp_raise_ValueError("Invalid UTXO type");
+      break;
+    case InvalidAmount:
+      mp_raise_ValueError("Invalid amount");
+      break;
+    case InvalidAccountCommand:
+      mp_raise_ValueError("Invalid account command");
+      break;
+    case InvalidDestination:
+      mp_raise_ValueError("Invalid destination");
+      break;
+    case InvalidIsTokenUnfreezable:
+      mp_raise_ValueError("Invalid token unfreezable flag");
+      break;
+    case InvalidIsTokenFreezable:
+      mp_raise_ValueError("Invalid token freezable flag");
+      break;
+    case InvalidVrfPublicKey:
+      mp_raise_ValueError("Invalid VRF public key");
+      break;
+    case InvalidPublicKey:
+      mp_raise_ValueError("Invalid public key");
+      break;
+    case InvalidOutputTimeLock:
+      mp_raise_ValueError("Invalid output time lock");
+      break;
+    case InvalidTokenTotalSupply:
+      mp_raise_ValueError("Invalid token total supply");
+      break;
+    default:
+      mp_raise_ValueError("Unknown error");
+      break;
+  }
+}

--- a/core/embed/upymod/modtrezormintlayer/utils.h
+++ b/core/embed/upymod/modtrezormintlayer/utils.h
@@ -1,0 +1,8 @@
+#ifndef MODTREZORMINTLAYER_UTILS_H
+#define MODTREZORMINTLAYER_UTILS_H
+
+#include "embed/rust/mintlayer.h"
+
+void handle_err(ByteArray *res);
+
+#endif  // MODTREZORMINTLAYER_UTILS_H

--- a/core/mocks/generated/trezormintlayer.pyi
+++ b/core/mocks/generated/trezormintlayer.pyi
@@ -1,6 +1,55 @@
 from typing import *
 
 
+# upymod/modtrezormintlayer/modtrezormintlayer-input-comm.h
+def encode_empty_input_commitment() -> bytes:
+    """
+    Encodes an empty input commitment.
+    """
+
+
+# upymod/modtrezormintlayer/modtrezormintlayer-input-comm.h
+def encode_input_commitment_for_utxo(encoded_utxo: bytes) -> bytes:
+    """
+    Encodes an input commitment for a utxo.
+    in v1 it works for any utxo input except ProduceBlockFromStake.
+    """
+
+
+# upymod/modtrezormintlayer/modtrezormintlayer-input-comm.h
+def encode_input_commitment_v1_for_produce_block_from_stake_utxo(
+  encoded_utxo: bytes, staker_balance_amount: bytes
+) -> bytes:
+    """
+    Encodes an input commitment for a ProduceBlockFromStake utxo (v1 only).
+    """
+
+
+# upymod/modtrezormintlayer/modtrezormintlayer-input-comm.h
+def encode_input_commitment_v1_for_fill_order(
+    asked_token: bytes, initially_asked_amount: bytes,
+    given_token: bytes, initially_given_amount: bytes,
+) -> bytes:
+    """
+    Encodes input commitment for filling an order (v1 only);
+    asked_token and given_token can be empty byte arrays, which means that
+    the corresponding
+    """
+
+
+# upymod/modtrezormintlayer/modtrezormintlayer-input-comm.h
+def encode_input_commitment_v1_for_conclude_order(
+    asked_token: bytes, initially_asked_amount: bytes, ask_balance_amount:
+    bytes, given_token: bytes, initially_given_amount: bytes,
+    give_balance_amount: bytes
+) -> bytes:
+    """
+    Encodes input commitment for concluding an order (v1 only);
+    asked_token and given_token can be empty byte arrays, which means that
+    the corresponding
+    """
+
+
 # upymod/modtrezormintlayer/modtrezormintlayer.h
 def encode_utxo_input(tx_hash: bytes, index: int, utxo_type: int) -> bytes:
     """
@@ -38,7 +87,7 @@ def encode_fill_order_account_command_input(nonce: int, order_id: bytes,
 amount: bytes, destination: bytes)
 -> bytes:
     """
-    encodes an fill order account command from the nonce, order id, output
+    encodes a fill order account command from the nonce, order id, output
     amount and destination
     """
 

--- a/core/src/apps/mintlayer/sign_tx/layout.py
+++ b/core/src/apps/mintlayer/sign_tx/layout.py
@@ -28,14 +28,19 @@ def format_coin_amount_int(
     if token is None:
         decimals = coininfo.decimals
         name = coininfo.coin_shortcut
+        amount_str = format_amount(amount_int, decimals)
+        return f"{amount_str} {name}"
     else:
         decimals = token.number_of_decimals
         ticker = token.token_ticker.decode("utf-8")
-        name = f"Unknown token with ID: {token.token_id} and ticker {ticker}"
+        decimal_amount_str = format_amount(amount_int, decimals)
 
-    amount_str = format_amount(amount_int, decimals)
-
-    return f"{amount_str} {name}"
+        # TODO: check if it's a known token, see https://github.com/mintlayer/mintlayer-trezor-firmware/issues/6
+        is_known_token = False
+        if is_known_token:
+            return f"{decimal_amount_str} {ticker}"
+        else:
+            return f"{amount_int} atoms (presumable decimal amount: {decimal_amount_str}) of unknown token with ID {token.token_id} and ticker {ticker}"
 
 
 def lock_to_string(lock: MintlayerOutputTimeLock) -> str:
@@ -100,7 +105,7 @@ Cost per block: {int.from_bytes(x.cost_per_block, "big")}
     elif output.create_delegation_id:
         x = output.create_delegation_id
         amount = ""
-        address_short = f"Address: {x.destination}\nPoolId: {x.pool_id}"
+        address_short = f"Owner: {x.destination}\nPool id: {x.pool_id}"
         address_label = "Create delegation"
     elif output.delegate_staking:
         x = output.delegate_staking
@@ -179,6 +184,8 @@ Give: {give_amount}"""
     else:
         raise DataError("Unhandled output type")
 
+    # TODO: it's better to confirm all outputs in a uniform way, see https://github.com/mintlayer/mintlayer-trezor-firmware/issues/4
+    # (the item about "output confirmation dialog").
     if amount:
         layout = layouts.confirm_output(
             address_short,

--- a/core/src/apps/mintlayer/sign_tx/signer.py
+++ b/core/src/apps/mintlayer/sign_tx/signer.py
@@ -133,7 +133,7 @@ class Mintlayer:
                 raise DataError("Transaction trying to print money")
 
             fee = total_inputs - total.amount
-            # FIXME new confirm total
+            # TODO: new confirm total
             await helpers.confirm_total(
                 total.amount, fee, self.coininfo, token_output_value
             )
@@ -149,10 +149,10 @@ class Mintlayer:
         workflow.autolock_interrupts_workflow = False
 
         # Serialize the inputs.
-        encoded_inputs, encoded_input_utxos = await self.step3_serialize_inputs()
+        encoded_inputs, encoded_input_commitments = await self.step3_serialize_inputs()
         if __debug__:
             log.debug(__name__, "encoded inputs: %s", str(encoded_inputs))
-            log.debug(__name__, "encoded utxos: %s", str(encoded_input_utxos))
+            log.debug(__name__, "encoded utxos: %s", str(encoded_input_commitments))
 
         # Serialize the outputs.
         encoded_outputs = await self.step4_serialize_outputs()
@@ -161,7 +161,7 @@ class Mintlayer:
 
         # Sign the inputs.
         signatures = await self.step5_sign_inputs(
-            encoded_inputs, encoded_input_utxos, encoded_outputs
+            encoded_inputs, encoded_input_commitments, encoded_outputs
         )
 
         # write the signatures
@@ -192,6 +192,15 @@ class Mintlayer:
         self,
     ) -> Dict[str, int]:
         tx_info = self.tx_info  # local_cache_attribute
+        # Note: the `totals` produced during input and output handling are used to calculate the fee
+        # and to check that the tx doesn't try to print money. This leads to some weirdness during
+        # `FillOrder` handling, where we add the "filled" amount (which is in the "give" curency)
+        # to `totals` instead of the "fill" amount (the one in the "ask" currency), which is
+        # actually present in the inputs. But we also show these `totals` to the user, which
+        # is confusing. Perhaps we should calculate the actual input amounts (to show them
+        # to the user) and the fictional amounts (to satisfy the output amounts) separately.
+        # (Note that we already have a TODO related to a custom "confirm_total" dialog, so this
+        # can be solved as part of the same task).
         totals: Dict[str, int] = {self.coininfo.coin_shortcut: 0}
 
         def nodes_for_addresses(
@@ -206,43 +215,47 @@ class Mintlayer:
             ]
 
         def update_totals_for_fill_order(
-            fill_amount_b: bytes,
-            ask_balance: MintlayerOutputValue,
-            give_balance: MintlayerOutputValue,
+            fill_amount_bytes: bytes,
+            ask_balance_bytes: bytes,
+            give_balance_bytes: bytes,
+            give_token_or_coin: str,
         ) -> None:
-            give_amount = int.from_bytes(give_balance.amount, "big")
-            fill_amount = int.from_bytes(fill_amount_b, "big")
-            ask_amount = int.from_bytes(ask_balance.amount, "big")
+            fill_amount = int.from_bytes(fill_amount_bytes, "big")
+            ask_balance = int.from_bytes(ask_balance_bytes, "big")
+            give_balance = int.from_bytes(give_balance_bytes, "big")
 
-            amount = (give_amount * fill_amount) // ask_amount
+            filled_amount = (give_balance * fill_amount) // ask_balance
 
-            give = give_balance
-            ask_token_or_coin = (
-                give.token.token_id if give.token else self.coininfo.coin_shortcut
+            totals[give_token_or_coin] = (
+                totals.get(give_token_or_coin, 0) + filled_amount
             )
-
-            totals[ask_token_or_coin] = totals.get(ask_token_or_coin, 0) + amount
 
         def update_totals_for_conclude_order(
-            filled_ask_value: MintlayerOutputValue, give_balance: MintlayerOutputValue
+            initially_asked_value: MintlayerOutputValue,
+            ask_balance_bytes: bytes,
+            initially_given_value: MintlayerOutputValue,
+            give_balance_bytes: bytes,
         ) -> None:
-            ask_amount = int.from_bytes(filled_ask_value.amount, "big")
             ask_token_or_coin = (
-                filled_ask_value.token.token_id
-                if filled_ask_value.token
+                initially_asked_value.token.token_id
+                if initially_asked_value.token
                 else self.coininfo.coin_shortcut
             )
-
-            totals[ask_token_or_coin] = totals.get(ask_token_or_coin, 0) + ask_amount
-
-            give_amount = int.from_bytes(give_balance.amount, "big")
+            initially_asked = int.from_bytes(initially_asked_value.amount, "big")
+            ask_balance = int.from_bytes(ask_balance_bytes, "big")
             give_token_or_coin = (
-                give_balance.token.token_id
-                if give_balance.token
+                initially_given_value.token.token_id
+                if initially_given_value.token
                 else self.coininfo.coin_shortcut
             )
+            give_balance = int.from_bytes(give_balance_bytes, "big")
 
-            totals[give_token_or_coin] = totals.get(give_token_or_coin, 0) + give_amount
+            filled_value = initially_asked - ask_balance
+
+            totals[ask_token_or_coin] = totals.get(ask_token_or_coin, 0) + filled_value
+            totals[give_token_or_coin] = (
+                totals.get(give_token_or_coin, 0) + give_balance
+            )
 
         for i in range(tx_info.tx.inputs_count):
             self.progress.advance()
@@ -286,14 +299,23 @@ class Mintlayer:
                     pass
                 elif x.conclude_order:
                     update_totals_for_conclude_order(
-                        x.conclude_order.filled_ask_amount,
+                        x.conclude_order.initially_asked,
+                        x.conclude_order.ask_balance,
+                        x.conclude_order.initially_given,
                         x.conclude_order.give_balance,
                     )
                 elif x.fill_order:
+                    given = x.fill_order.initially_given
+                    give_token_or_coin = (
+                        given.token.token_id
+                        if given.token
+                        else self.coininfo.coin_shortcut
+                    )
                     update_totals_for_fill_order(
                         x.fill_order.amount,
                         x.fill_order.ask_balance,
                         x.fill_order.give_balance,
+                        give_token_or_coin,
                     )
                 else:
                     raise DataError("Unknown account command")
@@ -302,14 +324,26 @@ class Mintlayer:
                 x = txi.order_command
                 nodes = nodes_for_addresses(x.addresses)
                 if x.fill:
+                    given = x.fill.initially_given
+                    give_token_or_coin = (
+                        given.token.token_id
+                        if given.token
+                        else self.coininfo.coin_shortcut
+                    )
                     update_totals_for_fill_order(
-                        x.fill.amount, x.fill.initially_asked, x.fill.initially_given
+                        x.fill.amount,
+                        x.fill.initially_asked.amount,
+                        x.fill.initially_given.amount,
+                        give_token_or_coin,
                     )
                 elif x.freeze:
                     pass
                 elif x.conclude:
                     update_totals_for_conclude_order(
-                        x.conclude.filled_ask_amount, x.conclude.give_balance
+                        x.conclude.initially_asked,
+                        x.conclude.ask_balance,
+                        x.conclude.initially_given,
+                        x.conclude.give_balance,
                     )
                 else:
                     raise DataError("Unknown order command")
@@ -341,7 +375,7 @@ class Mintlayer:
 
     async def step3_serialize_inputs(self) -> Tuple[List[bytes], List[bytes]]:
         encoded_inputs = []
-        encoded_input_utxos = []
+        encoded_input_commitments = []
         for inp in self.tx_info.inputs:
             self.progress.advance()
             if inp.input.utxo and inp.utxo:
@@ -351,9 +385,10 @@ class Mintlayer:
                 )
                 encoded_inputs.append(encoded_inp)
 
-                encoded_inp_utxo = self.serialize_output(inp.utxo)
-                # prepend \x01 for an active Option
-                encoded_input_utxos.append(b"\x01" + encoded_inp_utxo)
+                encoded_input_commitment = self.serialize_input_commitment_for_utxo(
+                    inp.utxo
+                )
+                encoded_input_commitments.append(encoded_input_commitment)
             elif inp.input.account:
                 a = inp.input.account
                 nonce = a.nonce
@@ -366,8 +401,9 @@ class Mintlayer:
                         nonce, delegation_id, deleg_balance.amount
                     )
                     encoded_inputs.append(encoded_inp)
-                    # just add a \x00 for an empty Option as accounts don't have an UTXO
-                    encoded_input_utxos.append(b"\x00")
+                    encoded_input_commitments.append(
+                        mintlayer_utils.encode_empty_input_commitment()
+                    )
                 else:
                     raise DataError("Unknown account spending")
             elif inp.input.account_command:
@@ -411,8 +447,16 @@ class Mintlayer:
                         )
                     )
                     encoded_inputs.append(encoded_inp)
-                    # just add a \x00 for an empty Option as account command inputs don't have an UTXO
-                    encoded_input_utxos.append(b"\x00")
+
+                    encoded_input_commitment = (
+                        self.serialize_input_commitment_for_conclude_order(
+                            ord.initially_asked,
+                            ord.ask_balance,
+                            ord.initially_given,
+                            ord.give_balance,
+                        )
+                    )
+                    encoded_input_commitments.append(encoded_input_commitment)
                     continue
                 elif x.fill_order:
                     ord = x.fill_order
@@ -428,8 +472,14 @@ class Mintlayer:
                         )
                     )
                     encoded_inputs.append(encoded_inp)
-                    # just add a \x00 for an empty Option as account command inputs don't have an UTXO
-                    encoded_input_utxos.append(b"\x00")
+
+                    encoded_input_commitment = (
+                        self.serialize_input_commitment_for_fill_order(
+                            ord.initially_asked,
+                            ord.initially_given,
+                        )
+                    )
+                    encoded_input_commitments.append(encoded_input_commitment)
                     continue
                 else:
                     raise DataError("Unknown account command")
@@ -441,8 +491,9 @@ class Mintlayer:
                     data,
                 )
                 encoded_inputs.append(encoded_inp)
-                # just add a \x00 for an empty Option as account command inputs don't have an UTXO
-                encoded_input_utxos.append(b"\x00")
+                encoded_input_commitments.append(
+                    mintlayer_utils.encode_empty_input_commitment()
+                )
             elif inp.input.order_command:
                 x = inp.input.order_command
 
@@ -456,10 +507,16 @@ class Mintlayer:
                         )
                     )
                     encoded_inputs.append(encoded_inp)
-                    # just add a \x00 for an empty Option as order command inputs don't have an UTXO
-                    # TODO: fix when input commitments are ready
-                    encoded_input_utxos.append(b"\x00")
-                    continue
+
+                    encoded_input_commitment = (
+                        self.serialize_input_commitment_for_conclude_order(
+                            ord.initially_asked,
+                            ord.ask_balance,
+                            ord.initially_given,
+                            ord.give_balance,
+                        )
+                    )
+                    encoded_input_commitments.append(encoded_input_commitment)
                 elif x.freeze:
                     ord = x.freeze
                     encoded_inp = (
@@ -470,9 +527,9 @@ class Mintlayer:
                         )
                     )
                     encoded_inputs.append(encoded_inp)
-                    # just add a \x00 for an empty Option as order command inputs don't have an UTXO
-                    encoded_input_utxos.append(b"\x00")
-                    continue
+                    encoded_input_commitments.append(
+                        mintlayer_utils.encode_empty_input_commitment()
+                    )
                 elif x.fill:
                     ord = x.fill
                     destination = decode_nullable_address(ord.destination)
@@ -486,16 +543,20 @@ class Mintlayer:
                         )
                     )
                     encoded_inputs.append(encoded_inp)
-                    # just add a \x00 for an empty Option as account command inputs don't have an UTXO
-                    # TODO: fix when input commitments are ready
-                    encoded_input_utxos.append(b"\x00")
-                    continue
+
+                    encoded_input_commitment = (
+                        self.serialize_input_commitment_for_fill_order(
+                            ord.initially_asked,
+                            ord.initially_given,
+                        )
+                    )
+                    encoded_input_commitments.append(encoded_input_commitment)
                 else:
                     raise DataError("Unknown account command")
             else:
                 raise DataError("Unknown input type")
 
-        return encoded_inputs, encoded_input_utxos
+        return encoded_inputs, encoded_input_commitments
 
     def serialize_output(self, out: MintlayerTxOutput) -> bytes:
         if out.transfer:
@@ -619,6 +680,82 @@ class Mintlayer:
             raise DataError("Unhandled tx output type")
         return encoded_out
 
+    def using_v1_input_commitments(self) -> bool:
+        ver = self.tx_info.tx.input_commitments_version
+        if ver == 0:
+            return False
+        elif ver == 1:
+            return True
+        else:
+            raise DataError("Unhandled input commitments version")
+
+    def serialize_input_commitment_for_utxo(self, out: MintlayerTxOutput) -> bytes:
+        encoded_utxo = self.serialize_output(out)
+
+        if out.produce_block_from_stake and self.using_v1_input_commitments():
+            staker_balance = out.produce_block_from_stake.staker_balance
+            encoded_comm = mintlayer_utils.encode_input_commitment_v1_for_produce_block_from_stake_utxo(
+                encoded_utxo, staker_balance
+            )
+        else:
+            encoded_comm = mintlayer_utils.encode_input_commitment_for_utxo(
+                encoded_utxo
+            )
+
+        return encoded_comm
+
+    def serialize_input_commitment_for_conclude_order(
+        self,
+        initially_asked: MintlayerOutputValue,
+        ask_balance: bytes,
+        initially_given: MintlayerOutputValue,
+        give_balance: bytes,
+    ) -> bytes:
+        if self.using_v1_input_commitments():
+            asked_token = decode_nullable_token_id(
+                initially_asked.token, self.coininfo.prefixes.token
+            )
+            given_token = decode_nullable_token_id(
+                initially_given.token, self.coininfo.prefixes.token
+            )
+            encoded_comm = (
+                mintlayer_utils.encode_input_commitment_v1_for_conclude_order(
+                    asked_token,
+                    initially_asked.amount,
+                    ask_balance,
+                    given_token,
+                    initially_given.amount,
+                    give_balance,
+                )
+            )
+        else:
+            encoded_comm = mintlayer_utils.encode_empty_input_commitment()
+
+        return encoded_comm
+
+    def serialize_input_commitment_for_fill_order(
+        self,
+        initially_asked: MintlayerOutputValue,
+        initially_given: MintlayerOutputValue,
+    ) -> bytes:
+        if self.using_v1_input_commitments():
+            asked_token = decode_nullable_token_id(
+                initially_asked.token, self.coininfo.prefixes.token
+            )
+            given_token = decode_nullable_token_id(
+                initially_given.token, self.coininfo.prefixes.token
+            )
+            encoded_comm = mintlayer_utils.encode_input_commitment_v1_for_fill_order(
+                asked_token,
+                initially_asked.amount,
+                given_token,
+                initially_given.amount,
+            )
+        else:
+            encoded_comm = mintlayer_utils.encode_empty_input_commitment()
+
+        return encoded_comm
+
     async def step4_serialize_outputs(self) -> List[bytes]:
         encoded_outputs = []
         for out in self.tx_info.outputs:
@@ -631,15 +768,15 @@ class Mintlayer:
     async def step5_sign_inputs(
         self,
         encoded_inputs: List[bytes],
-        encoded_input_utxos: List[bytes],
+        encoded_input_commitments: List[bytes],
         encoded_outputs: List[bytes],
     ) -> List[List[Tuple[bytes, int | None]]]:
         from trezor.utils import HashWriter
 
         signatures = []
-        if len(encoded_inputs) != len(encoded_input_utxos):
+        if len(encoded_inputs) != len(encoded_input_commitments):
             raise DataError(
-                "number of encoded utxos not the same as the number of inputs"
+                "number of input commitments not the same as the number of inputs"
             )
 
         for i in range(self.tx_info.tx.inputs_count):
@@ -658,9 +795,9 @@ class Mintlayer:
                 for inp in encoded_inputs:
                     writer.extend(inp)
 
-                writer.extend(len(encoded_input_utxos).to_bytes(4, "little"))
-                for utxo in encoded_input_utxos:
-                    writer.extend(utxo)
+                writer.extend(len(encoded_input_commitments).to_bytes(4, "little"))
+                for commitment in encoded_input_commitments:
+                    writer.extend(commitment)
 
                 encoded_len = mintlayer_utils.encode_compact_length(
                     len(encoded_outputs)
@@ -747,15 +884,25 @@ def update_output_totals(
         update(txo.lock_then_transfer.value)
     elif txo.burn:
         update(txo.burn.value)
-    elif txo.issue_nft:
-        pass
     elif txo.create_stake_pool:
         amount = int.from_bytes(txo.create_stake_pool.pledge, "big")
         totals[ml_coin].amount += amount
+    elif txo.produce_block_from_stake:
+        pass
+    elif txo.create_delegation_id:
+        pass
     elif txo.delegate_staking:
         amount = int.from_bytes(txo.delegate_staking.amount, "big")
         totals[ml_coin].amount += amount
+    elif txo.issue_fungible_token:
+        pass
+    elif txo.issue_nft:
+        pass
+    elif txo.data_deposit:
+        pass
     elif txo.htlc:
         update(txo.htlc.value)
     elif txo.create_order:
         pass
+    else:
+        raise DataError("Unhandled TX output type in update_output_totals")

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -4132,6 +4132,7 @@ if TYPE_CHECKING:
         outputs_count: "int"
         inputs_count: "int"
         chain_type: "MintlayerChainType"
+        input_commitments_version: "int"
         version: "int"
         chunkify: "bool | None"
 
@@ -4141,6 +4142,7 @@ if TYPE_CHECKING:
             outputs_count: "int",
             inputs_count: "int",
             chain_type: "MintlayerChainType",
+            input_commitments_version: "int",
             version: "int | None" = None,
             chunkify: "bool | None" = None,
         ) -> None:
@@ -4330,15 +4332,19 @@ if TYPE_CHECKING:
 
     class MintlayerConcludeOrderV1(protobuf.MessageType):
         order_id: "str"
-        filled_ask_amount: "MintlayerOutputValue"
-        give_balance: "MintlayerOutputValue"
+        initially_asked: "MintlayerOutputValue"
+        initially_given: "MintlayerOutputValue"
+        ask_balance: "bytes"
+        give_balance: "bytes"
 
         def __init__(
             self,
             *,
             order_id: "str",
-            filled_ask_amount: "MintlayerOutputValue",
-            give_balance: "MintlayerOutputValue",
+            initially_asked: "MintlayerOutputValue",
+            initially_given: "MintlayerOutputValue",
+            ask_balance: "bytes",
+            give_balance: "bytes",
         ) -> None:
             pass
 
@@ -4438,15 +4444,19 @@ if TYPE_CHECKING:
 
     class MintlayerConcludeOrder(protobuf.MessageType):
         order_id: "str"
-        filled_ask_amount: "MintlayerOutputValue"
-        give_balance: "MintlayerOutputValue"
+        initially_asked: "MintlayerOutputValue"
+        initially_given: "MintlayerOutputValue"
+        ask_balance: "bytes"
+        give_balance: "bytes"
 
         def __init__(
             self,
             *,
             order_id: "str",
-            filled_ask_amount: "MintlayerOutputValue",
-            give_balance: "MintlayerOutputValue",
+            initially_asked: "MintlayerOutputValue",
+            initially_given: "MintlayerOutputValue",
+            ask_balance: "bytes",
+            give_balance: "bytes",
         ) -> None:
             pass
 
@@ -4458,8 +4468,10 @@ if TYPE_CHECKING:
         order_id: "str"
         amount: "bytes"
         destination: "str"
-        ask_balance: "MintlayerOutputValue"
-        give_balance: "MintlayerOutputValue"
+        initially_asked: "MintlayerOutputValue"
+        initially_given: "MintlayerOutputValue"
+        ask_balance: "bytes"
+        give_balance: "bytes"
 
         def __init__(
             self,
@@ -4467,8 +4479,10 @@ if TYPE_CHECKING:
             order_id: "str",
             amount: "bytes",
             destination: "str",
-            ask_balance: "MintlayerOutputValue",
-            give_balance: "MintlayerOutputValue",
+            initially_asked: "MintlayerOutputValue",
+            initially_given: "MintlayerOutputValue",
+            ask_balance: "bytes",
+            give_balance: "bytes",
         ) -> None:
             pass
 

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -5588,8 +5588,9 @@ class MintlayerSignTx(protobuf.MessageType):
         1: protobuf.Field("outputs_count", "uint32", repeated=False, required=True),
         2: protobuf.Field("inputs_count", "uint32", repeated=False, required=True),
         3: protobuf.Field("chain_type", "MintlayerChainType", repeated=False, required=True),
-        4: protobuf.Field("version", "uint32", repeated=False, required=False, default=1),
-        5: protobuf.Field("chunkify", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("input_commitments_version", "uint32", repeated=False, required=True),
+        5: protobuf.Field("version", "uint32", repeated=False, required=False, default=1),
+        6: protobuf.Field("chunkify", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5598,12 +5599,14 @@ class MintlayerSignTx(protobuf.MessageType):
         outputs_count: "int",
         inputs_count: "int",
         chain_type: "MintlayerChainType",
+        input_commitments_version: "int",
         version: Optional["int"] = 1,
         chunkify: Optional["bool"] = None,
     ) -> None:
         self.outputs_count = outputs_count
         self.inputs_count = inputs_count
         self.chain_type = chain_type
+        self.input_commitments_version = input_commitments_version
         self.version = version
         self.chunkify = chunkify
 
@@ -5816,19 +5819,25 @@ class MintlayerConcludeOrderV1(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("order_id", "string", repeated=False, required=True),
-        2: protobuf.Field("filled_ask_amount", "MintlayerOutputValue", repeated=False, required=True),
-        3: protobuf.Field("give_balance", "MintlayerOutputValue", repeated=False, required=True),
+        2: protobuf.Field("initially_asked", "MintlayerOutputValue", repeated=False, required=True),
+        3: protobuf.Field("initially_given", "MintlayerOutputValue", repeated=False, required=True),
+        4: protobuf.Field("ask_balance", "bytes", repeated=False, required=True),
+        5: protobuf.Field("give_balance", "bytes", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
         order_id: "str",
-        filled_ask_amount: "MintlayerOutputValue",
-        give_balance: "MintlayerOutputValue",
+        initially_asked: "MintlayerOutputValue",
+        initially_given: "MintlayerOutputValue",
+        ask_balance: "bytes",
+        give_balance: "bytes",
     ) -> None:
         self.order_id = order_id
-        self.filled_ask_amount = filled_ask_amount
+        self.initially_asked = initially_asked
+        self.initially_given = initially_given
+        self.ask_balance = ask_balance
         self.give_balance = give_balance
 
 
@@ -5929,19 +5938,25 @@ class MintlayerConcludeOrder(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("order_id", "string", repeated=False, required=True),
-        2: protobuf.Field("filled_ask_amount", "MintlayerOutputValue", repeated=False, required=True),
-        3: protobuf.Field("give_balance", "MintlayerOutputValue", repeated=False, required=True),
+        2: protobuf.Field("initially_asked", "MintlayerOutputValue", repeated=False, required=True),
+        3: protobuf.Field("initially_given", "MintlayerOutputValue", repeated=False, required=True),
+        4: protobuf.Field("ask_balance", "bytes", repeated=False, required=True),
+        5: protobuf.Field("give_balance", "bytes", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
         order_id: "str",
-        filled_ask_amount: "MintlayerOutputValue",
-        give_balance: "MintlayerOutputValue",
+        initially_asked: "MintlayerOutputValue",
+        initially_given: "MintlayerOutputValue",
+        ask_balance: "bytes",
+        give_balance: "bytes",
     ) -> None:
         self.order_id = order_id
-        self.filled_ask_amount = filled_ask_amount
+        self.initially_asked = initially_asked
+        self.initially_given = initially_given
+        self.ask_balance = ask_balance
         self.give_balance = give_balance
 
 
@@ -5951,8 +5966,10 @@ class MintlayerFillOrder(protobuf.MessageType):
         1: protobuf.Field("order_id", "string", repeated=False, required=True),
         2: protobuf.Field("amount", "bytes", repeated=False, required=True),
         3: protobuf.Field("destination", "string", repeated=False, required=True),
-        4: protobuf.Field("ask_balance", "MintlayerOutputValue", repeated=False, required=True),
-        5: protobuf.Field("give_balance", "MintlayerOutputValue", repeated=False, required=True),
+        4: protobuf.Field("initially_asked", "MintlayerOutputValue", repeated=False, required=True),
+        5: protobuf.Field("initially_given", "MintlayerOutputValue", repeated=False, required=True),
+        6: protobuf.Field("ask_balance", "bytes", repeated=False, required=True),
+        7: protobuf.Field("give_balance", "bytes", repeated=False, required=True),
     }
 
     def __init__(
@@ -5961,12 +5978,16 @@ class MintlayerFillOrder(protobuf.MessageType):
         order_id: "str",
         amount: "bytes",
         destination: "str",
-        ask_balance: "MintlayerOutputValue",
-        give_balance: "MintlayerOutputValue",
+        initially_asked: "MintlayerOutputValue",
+        initially_given: "MintlayerOutputValue",
+        ask_balance: "bytes",
+        give_balance: "bytes",
     ) -> None:
         self.order_id = order_id
         self.amount = amount
         self.destination = destination
+        self.initially_asked = initially_asked
+        self.initially_given = initially_given
         self.ask_balance = ask_balance
         self.give_balance = give_balance
 

--- a/python/src/trezorlib/mintlayer.py
+++ b/python/src/trezorlib/mintlayer.py
@@ -102,6 +102,7 @@ def sign_tx(
     inputs: List[Input],
     outputs: List[Output],
     prev_txs: Dict[TxHash, Dict[int, Output]],
+    input_commitments_version: int = 0,
     version: Optional["int"] = 1,
     chunkify: Optional["bool"] = None,
 ) -> List[messages.MintlayerSignaturesForInput]:
@@ -110,6 +111,7 @@ def sign_tx(
             outputs_count=len(outputs),
             inputs_count=len(inputs),
             chain_type=messages.MintlayerChainType(chain_type),
+            input_commitments_version=input_commitments_version,
             version=version,
             chunkify=chunkify,
         )

--- a/rust/trezor-client/src/client/mintlayer.rs
+++ b/rust/trezor-client/src/client/mintlayer.rs
@@ -37,6 +37,21 @@ impl MintlayerSignature {
 
 pub type TransactionId = [u8; 32];
 
+#[derive(Debug, Clone, Copy)]
+pub enum SighashInputCommitmentsVersion {
+    V0,
+    V1,
+}
+
+impl SighashInputCommitmentsVersion {
+    fn as_msg_param(self) -> u32 {
+        match self {
+            SighashInputCommitmentsVersion::V0 => 0,
+            SighashInputCommitmentsVersion::V1 => 1,
+        }
+    }
+}
+
 impl Trezor {
     // Mintlayer
     pub fn mintlayer_get_public_key(
@@ -88,12 +103,14 @@ impl Trezor {
         inputs: Vec<MintlayerTxInput>,
         outputs: Vec<MintlayerTxOutput>,
         utxos: BTreeMap<TransactionId, BTreeMap<u32, MintlayerTxOutput>>,
+        input_commitments_version: SighashInputCommitmentsVersion,
     ) -> Result<Vec<Vec<MintlayerSignature>>> {
         let mut req = protos::MintlayerSignTx::new();
         req.set_version(1);
         req.set_chain_type(chain_type);
         req.set_inputs_count(inputs.len() as u32);
         req.set_outputs_count(outputs.len() as u32);
+        req.set_input_commitments_version(input_commitments_version.as_msg_param());
 
         let mut msg = self.call::<_, _, protos::MintlayerTxRequest>(req, Box::new(|_, m| Ok(m)))?;
         loop {

--- a/rust/trezor-client/src/protos/generated/messages_mintlayer.rs
+++ b/rust/trezor-client/src/protos/generated/messages_mintlayer.rs
@@ -1129,6 +1129,8 @@ pub struct MintlayerSignTx {
     pub inputs_count: ::std::option::Option<u32>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerSignTx.chain_type)
     pub chain_type: ::std::option::Option<::protobuf::EnumOrUnknown<MintlayerChainType>>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerSignTx.input_commitments_version)
+    pub input_commitments_version: ::std::option::Option<u32>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerSignTx.version)
     pub version: ::std::option::Option<u32>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerSignTx.chunkify)
@@ -1209,7 +1211,26 @@ impl MintlayerSignTx {
         self.chain_type = ::std::option::Option::Some(::protobuf::EnumOrUnknown::new(v));
     }
 
-    // optional uint32 version = 4;
+    // required uint32 input_commitments_version = 4;
+
+    pub fn input_commitments_version(&self) -> u32 {
+        self.input_commitments_version.unwrap_or(0)
+    }
+
+    pub fn clear_input_commitments_version(&mut self) {
+        self.input_commitments_version = ::std::option::Option::None;
+    }
+
+    pub fn has_input_commitments_version(&self) -> bool {
+        self.input_commitments_version.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_input_commitments_version(&mut self, v: u32) {
+        self.input_commitments_version = ::std::option::Option::Some(v);
+    }
+
+    // optional uint32 version = 5;
 
     pub fn version(&self) -> u32 {
         self.version.unwrap_or(1u32)
@@ -1228,7 +1249,7 @@ impl MintlayerSignTx {
         self.version = ::std::option::Option::Some(v);
     }
 
-    // optional bool chunkify = 5;
+    // optional bool chunkify = 6;
 
     pub fn chunkify(&self) -> bool {
         self.chunkify.unwrap_or(false)
@@ -1248,7 +1269,7 @@ impl MintlayerSignTx {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(5);
+        let mut fields = ::std::vec::Vec::with_capacity(6);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "outputs_count",
@@ -1264,6 +1285,11 @@ impl MintlayerSignTx {
             "chain_type",
             |m: &MintlayerSignTx| { &m.chain_type },
             |m: &mut MintlayerSignTx| { &mut m.chain_type },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "input_commitments_version",
+            |m: &MintlayerSignTx| { &m.input_commitments_version },
+            |m: &mut MintlayerSignTx| { &mut m.input_commitments_version },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "version",
@@ -1296,6 +1322,9 @@ impl ::protobuf::Message for MintlayerSignTx {
         if self.chain_type.is_none() {
             return false;
         }
+        if self.input_commitments_version.is_none() {
+            return false;
+        }
         true
     }
 
@@ -1312,9 +1341,12 @@ impl ::protobuf::Message for MintlayerSignTx {
                     self.chain_type = ::std::option::Option::Some(is.read_enum_or_unknown()?);
                 },
                 32 => {
-                    self.version = ::std::option::Option::Some(is.read_uint32()?);
+                    self.input_commitments_version = ::std::option::Option::Some(is.read_uint32()?);
                 },
                 40 => {
+                    self.version = ::std::option::Option::Some(is.read_uint32()?);
+                },
+                48 => {
                     self.chunkify = ::std::option::Option::Some(is.read_bool()?);
                 },
                 tag => {
@@ -1338,8 +1370,11 @@ impl ::protobuf::Message for MintlayerSignTx {
         if let Some(v) = self.chain_type {
             my_size += ::protobuf::rt::int32_size(3, v.value());
         }
-        if let Some(v) = self.version {
+        if let Some(v) = self.input_commitments_version {
             my_size += ::protobuf::rt::uint32_size(4, v);
+        }
+        if let Some(v) = self.version {
+            my_size += ::protobuf::rt::uint32_size(5, v);
         }
         if let Some(v) = self.chunkify {
             my_size += 1 + 1;
@@ -1359,11 +1394,14 @@ impl ::protobuf::Message for MintlayerSignTx {
         if let Some(v) = self.chain_type {
             os.write_enum(3, ::protobuf::EnumOrUnknown::value(&v))?;
         }
-        if let Some(v) = self.version {
+        if let Some(v) = self.input_commitments_version {
             os.write_uint32(4, v)?;
         }
+        if let Some(v) = self.version {
+            os.write_uint32(5, v)?;
+        }
         if let Some(v) = self.chunkify {
-            os.write_bool(5, v)?;
+            os.write_bool(6, v)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -1385,6 +1423,7 @@ impl ::protobuf::Message for MintlayerSignTx {
         self.outputs_count = ::std::option::Option::None;
         self.inputs_count = ::std::option::Option::None;
         self.chain_type = ::std::option::Option::None;
+        self.input_commitments_version = ::std::option::Option::None;
         self.version = ::std::option::Option::None;
         self.chunkify = ::std::option::Option::None;
         self.special_fields.clear();
@@ -1395,6 +1434,7 @@ impl ::protobuf::Message for MintlayerSignTx {
             outputs_count: ::std::option::Option::None,
             inputs_count: ::std::option::Option::None,
             chain_type: ::std::option::Option::None,
+            input_commitments_version: ::std::option::Option::None,
             version: ::std::option::Option::None,
             chunkify: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
@@ -4355,10 +4395,14 @@ pub struct MintlayerConcludeOrderV1 {
     // message fields
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrderV1.order_id)
     pub order_id: ::std::option::Option<::std::string::String>,
-    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrderV1.filled_ask_amount)
-    pub filled_ask_amount: ::protobuf::MessageField<MintlayerOutputValue>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrderV1.initially_asked)
+    pub initially_asked: ::protobuf::MessageField<MintlayerOutputValue>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrderV1.initially_given)
+    pub initially_given: ::protobuf::MessageField<MintlayerOutputValue>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrderV1.ask_balance)
+    pub ask_balance: ::std::option::Option<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrderV1.give_balance)
-    pub give_balance: ::protobuf::MessageField<MintlayerOutputValue>,
+    pub give_balance: ::std::option::Option<::std::vec::Vec<u8>>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.mintlayer.MintlayerConcludeOrderV1.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -4411,8 +4455,80 @@ impl MintlayerConcludeOrderV1 {
         self.order_id.take().unwrap_or_else(|| ::std::string::String::new())
     }
 
+    // required bytes ask_balance = 4;
+
+    pub fn ask_balance(&self) -> &[u8] {
+        match self.ask_balance.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_ask_balance(&mut self) {
+        self.ask_balance = ::std::option::Option::None;
+    }
+
+    pub fn has_ask_balance(&self) -> bool {
+        self.ask_balance.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ask_balance(&mut self, v: ::std::vec::Vec<u8>) {
+        self.ask_balance = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_ask_balance(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.ask_balance.is_none() {
+            self.ask_balance = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.ask_balance.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_ask_balance(&mut self) -> ::std::vec::Vec<u8> {
+        self.ask_balance.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    // required bytes give_balance = 5;
+
+    pub fn give_balance(&self) -> &[u8] {
+        match self.give_balance.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_give_balance(&mut self) {
+        self.give_balance = ::std::option::Option::None;
+    }
+
+    pub fn has_give_balance(&self) -> bool {
+        self.give_balance.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_give_balance(&mut self, v: ::std::vec::Vec<u8>) {
+        self.give_balance = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_give_balance(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.give_balance.is_none() {
+            self.give_balance = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.give_balance.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_give_balance(&mut self) -> ::std::vec::Vec<u8> {
+        self.give_balance.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(3);
+        let mut fields = ::std::vec::Vec::with_capacity(5);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "order_id",
@@ -4420,11 +4536,21 @@ impl MintlayerConcludeOrderV1 {
             |m: &mut MintlayerConcludeOrderV1| { &mut m.order_id },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MintlayerOutputValue>(
-            "filled_ask_amount",
-            |m: &MintlayerConcludeOrderV1| { &m.filled_ask_amount },
-            |m: &mut MintlayerConcludeOrderV1| { &mut m.filled_ask_amount },
+            "initially_asked",
+            |m: &MintlayerConcludeOrderV1| { &m.initially_asked },
+            |m: &mut MintlayerConcludeOrderV1| { &mut m.initially_asked },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MintlayerOutputValue>(
+            "initially_given",
+            |m: &MintlayerConcludeOrderV1| { &m.initially_given },
+            |m: &mut MintlayerConcludeOrderV1| { &mut m.initially_given },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "ask_balance",
+            |m: &MintlayerConcludeOrderV1| { &m.ask_balance },
+            |m: &mut MintlayerConcludeOrderV1| { &mut m.ask_balance },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "give_balance",
             |m: &MintlayerConcludeOrderV1| { &m.give_balance },
             |m: &mut MintlayerConcludeOrderV1| { &mut m.give_balance },
@@ -4444,18 +4570,24 @@ impl ::protobuf::Message for MintlayerConcludeOrderV1 {
         if self.order_id.is_none() {
             return false;
         }
-        if self.filled_ask_amount.is_none() {
+        if self.initially_asked.is_none() {
+            return false;
+        }
+        if self.initially_given.is_none() {
+            return false;
+        }
+        if self.ask_balance.is_none() {
             return false;
         }
         if self.give_balance.is_none() {
             return false;
         }
-        for v in &self.filled_ask_amount {
+        for v in &self.initially_asked {
             if !v.is_initialized() {
                 return false;
             }
         };
-        for v in &self.give_balance {
+        for v in &self.initially_given {
             if !v.is_initialized() {
                 return false;
             }
@@ -4470,10 +4602,16 @@ impl ::protobuf::Message for MintlayerConcludeOrderV1 {
                     self.order_id = ::std::option::Option::Some(is.read_string()?);
                 },
                 18 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.filled_ask_amount)?;
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.initially_asked)?;
                 },
                 26 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.give_balance)?;
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.initially_given)?;
+                },
+                34 => {
+                    self.ask_balance = ::std::option::Option::Some(is.read_bytes()?);
+                },
+                42 => {
+                    self.give_balance = ::std::option::Option::Some(is.read_bytes()?);
                 },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
@@ -4490,13 +4628,19 @@ impl ::protobuf::Message for MintlayerConcludeOrderV1 {
         if let Some(v) = self.order_id.as_ref() {
             my_size += ::protobuf::rt::string_size(1, &v);
         }
-        if let Some(v) = self.filled_ask_amount.as_ref() {
+        if let Some(v) = self.initially_asked.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
         }
-        if let Some(v) = self.give_balance.as_ref() {
+        if let Some(v) = self.initially_given.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
+        if let Some(v) = self.ask_balance.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(4, &v);
+        }
+        if let Some(v) = self.give_balance.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(5, &v);
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
@@ -4507,11 +4651,17 @@ impl ::protobuf::Message for MintlayerConcludeOrderV1 {
         if let Some(v) = self.order_id.as_ref() {
             os.write_string(1, v)?;
         }
-        if let Some(v) = self.filled_ask_amount.as_ref() {
+        if let Some(v) = self.initially_asked.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(2, v, os)?;
         }
-        if let Some(v) = self.give_balance.as_ref() {
+        if let Some(v) = self.initially_given.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(3, v, os)?;
+        }
+        if let Some(v) = self.ask_balance.as_ref() {
+            os.write_bytes(4, v)?;
+        }
+        if let Some(v) = self.give_balance.as_ref() {
+            os.write_bytes(5, v)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -4531,16 +4681,20 @@ impl ::protobuf::Message for MintlayerConcludeOrderV1 {
 
     fn clear(&mut self) {
         self.order_id = ::std::option::Option::None;
-        self.filled_ask_amount.clear();
-        self.give_balance.clear();
+        self.initially_asked.clear();
+        self.initially_given.clear();
+        self.ask_balance = ::std::option::Option::None;
+        self.give_balance = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
     fn default_instance() -> &'static MintlayerConcludeOrderV1 {
         static instance: MintlayerConcludeOrderV1 = MintlayerConcludeOrderV1 {
             order_id: ::std::option::Option::None,
-            filled_ask_amount: ::protobuf::MessageField::none(),
-            give_balance: ::protobuf::MessageField::none(),
+            initially_asked: ::protobuf::MessageField::none(),
+            initially_given: ::protobuf::MessageField::none(),
+            ask_balance: ::std::option::Option::None,
+            give_balance: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -5690,10 +5844,14 @@ pub struct MintlayerConcludeOrder {
     // message fields
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrder.order_id)
     pub order_id: ::std::option::Option<::std::string::String>,
-    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrder.filled_ask_amount)
-    pub filled_ask_amount: ::protobuf::MessageField<MintlayerOutputValue>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrder.initially_asked)
+    pub initially_asked: ::protobuf::MessageField<MintlayerOutputValue>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrder.initially_given)
+    pub initially_given: ::protobuf::MessageField<MintlayerOutputValue>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrder.ask_balance)
+    pub ask_balance: ::std::option::Option<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerConcludeOrder.give_balance)
-    pub give_balance: ::protobuf::MessageField<MintlayerOutputValue>,
+    pub give_balance: ::std::option::Option<::std::vec::Vec<u8>>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.mintlayer.MintlayerConcludeOrder.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -5746,8 +5904,80 @@ impl MintlayerConcludeOrder {
         self.order_id.take().unwrap_or_else(|| ::std::string::String::new())
     }
 
+    // required bytes ask_balance = 4;
+
+    pub fn ask_balance(&self) -> &[u8] {
+        match self.ask_balance.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_ask_balance(&mut self) {
+        self.ask_balance = ::std::option::Option::None;
+    }
+
+    pub fn has_ask_balance(&self) -> bool {
+        self.ask_balance.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ask_balance(&mut self, v: ::std::vec::Vec<u8>) {
+        self.ask_balance = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_ask_balance(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.ask_balance.is_none() {
+            self.ask_balance = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.ask_balance.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_ask_balance(&mut self) -> ::std::vec::Vec<u8> {
+        self.ask_balance.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    // required bytes give_balance = 5;
+
+    pub fn give_balance(&self) -> &[u8] {
+        match self.give_balance.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_give_balance(&mut self) {
+        self.give_balance = ::std::option::Option::None;
+    }
+
+    pub fn has_give_balance(&self) -> bool {
+        self.give_balance.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_give_balance(&mut self, v: ::std::vec::Vec<u8>) {
+        self.give_balance = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_give_balance(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.give_balance.is_none() {
+            self.give_balance = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.give_balance.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_give_balance(&mut self) -> ::std::vec::Vec<u8> {
+        self.give_balance.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(3);
+        let mut fields = ::std::vec::Vec::with_capacity(5);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "order_id",
@@ -5755,11 +5985,21 @@ impl MintlayerConcludeOrder {
             |m: &mut MintlayerConcludeOrder| { &mut m.order_id },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MintlayerOutputValue>(
-            "filled_ask_amount",
-            |m: &MintlayerConcludeOrder| { &m.filled_ask_amount },
-            |m: &mut MintlayerConcludeOrder| { &mut m.filled_ask_amount },
+            "initially_asked",
+            |m: &MintlayerConcludeOrder| { &m.initially_asked },
+            |m: &mut MintlayerConcludeOrder| { &mut m.initially_asked },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MintlayerOutputValue>(
+            "initially_given",
+            |m: &MintlayerConcludeOrder| { &m.initially_given },
+            |m: &mut MintlayerConcludeOrder| { &mut m.initially_given },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "ask_balance",
+            |m: &MintlayerConcludeOrder| { &m.ask_balance },
+            |m: &mut MintlayerConcludeOrder| { &mut m.ask_balance },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "give_balance",
             |m: &MintlayerConcludeOrder| { &m.give_balance },
             |m: &mut MintlayerConcludeOrder| { &mut m.give_balance },
@@ -5779,18 +6019,24 @@ impl ::protobuf::Message for MintlayerConcludeOrder {
         if self.order_id.is_none() {
             return false;
         }
-        if self.filled_ask_amount.is_none() {
+        if self.initially_asked.is_none() {
+            return false;
+        }
+        if self.initially_given.is_none() {
+            return false;
+        }
+        if self.ask_balance.is_none() {
             return false;
         }
         if self.give_balance.is_none() {
             return false;
         }
-        for v in &self.filled_ask_amount {
+        for v in &self.initially_asked {
             if !v.is_initialized() {
                 return false;
             }
         };
-        for v in &self.give_balance {
+        for v in &self.initially_given {
             if !v.is_initialized() {
                 return false;
             }
@@ -5805,10 +6051,16 @@ impl ::protobuf::Message for MintlayerConcludeOrder {
                     self.order_id = ::std::option::Option::Some(is.read_string()?);
                 },
                 18 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.filled_ask_amount)?;
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.initially_asked)?;
                 },
                 26 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.give_balance)?;
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.initially_given)?;
+                },
+                34 => {
+                    self.ask_balance = ::std::option::Option::Some(is.read_bytes()?);
+                },
+                42 => {
+                    self.give_balance = ::std::option::Option::Some(is.read_bytes()?);
                 },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
@@ -5825,13 +6077,19 @@ impl ::protobuf::Message for MintlayerConcludeOrder {
         if let Some(v) = self.order_id.as_ref() {
             my_size += ::protobuf::rt::string_size(1, &v);
         }
-        if let Some(v) = self.filled_ask_amount.as_ref() {
+        if let Some(v) = self.initially_asked.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
         }
-        if let Some(v) = self.give_balance.as_ref() {
+        if let Some(v) = self.initially_given.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
+        if let Some(v) = self.ask_balance.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(4, &v);
+        }
+        if let Some(v) = self.give_balance.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(5, &v);
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
@@ -5842,11 +6100,17 @@ impl ::protobuf::Message for MintlayerConcludeOrder {
         if let Some(v) = self.order_id.as_ref() {
             os.write_string(1, v)?;
         }
-        if let Some(v) = self.filled_ask_amount.as_ref() {
+        if let Some(v) = self.initially_asked.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(2, v, os)?;
         }
-        if let Some(v) = self.give_balance.as_ref() {
+        if let Some(v) = self.initially_given.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(3, v, os)?;
+        }
+        if let Some(v) = self.ask_balance.as_ref() {
+            os.write_bytes(4, v)?;
+        }
+        if let Some(v) = self.give_balance.as_ref() {
+            os.write_bytes(5, v)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -5866,16 +6130,20 @@ impl ::protobuf::Message for MintlayerConcludeOrder {
 
     fn clear(&mut self) {
         self.order_id = ::std::option::Option::None;
-        self.filled_ask_amount.clear();
-        self.give_balance.clear();
+        self.initially_asked.clear();
+        self.initially_given.clear();
+        self.ask_balance = ::std::option::Option::None;
+        self.give_balance = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
     fn default_instance() -> &'static MintlayerConcludeOrder {
         static instance: MintlayerConcludeOrder = MintlayerConcludeOrder {
             order_id: ::std::option::Option::None,
-            filled_ask_amount: ::protobuf::MessageField::none(),
-            give_balance: ::protobuf::MessageField::none(),
+            initially_asked: ::protobuf::MessageField::none(),
+            initially_given: ::protobuf::MessageField::none(),
+            ask_balance: ::std::option::Option::None,
+            give_balance: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -5909,10 +6177,14 @@ pub struct MintlayerFillOrder {
     pub amount: ::std::option::Option<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerFillOrder.destination)
     pub destination: ::std::option::Option<::std::string::String>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerFillOrder.initially_asked)
+    pub initially_asked: ::protobuf::MessageField<MintlayerOutputValue>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerFillOrder.initially_given)
+    pub initially_given: ::protobuf::MessageField<MintlayerOutputValue>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerFillOrder.ask_balance)
-    pub ask_balance: ::protobuf::MessageField<MintlayerOutputValue>,
+    pub ask_balance: ::std::option::Option<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.mintlayer.MintlayerFillOrder.give_balance)
-    pub give_balance: ::protobuf::MessageField<MintlayerOutputValue>,
+    pub give_balance: ::std::option::Option<::std::vec::Vec<u8>>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.mintlayer.MintlayerFillOrder.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -6037,8 +6309,80 @@ impl MintlayerFillOrder {
         self.destination.take().unwrap_or_else(|| ::std::string::String::new())
     }
 
+    // required bytes ask_balance = 6;
+
+    pub fn ask_balance(&self) -> &[u8] {
+        match self.ask_balance.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_ask_balance(&mut self) {
+        self.ask_balance = ::std::option::Option::None;
+    }
+
+    pub fn has_ask_balance(&self) -> bool {
+        self.ask_balance.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_ask_balance(&mut self, v: ::std::vec::Vec<u8>) {
+        self.ask_balance = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_ask_balance(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.ask_balance.is_none() {
+            self.ask_balance = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.ask_balance.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_ask_balance(&mut self) -> ::std::vec::Vec<u8> {
+        self.ask_balance.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    // required bytes give_balance = 7;
+
+    pub fn give_balance(&self) -> &[u8] {
+        match self.give_balance.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_give_balance(&mut self) {
+        self.give_balance = ::std::option::Option::None;
+    }
+
+    pub fn has_give_balance(&self) -> bool {
+        self.give_balance.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_give_balance(&mut self, v: ::std::vec::Vec<u8>) {
+        self.give_balance = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_give_balance(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.give_balance.is_none() {
+            self.give_balance = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.give_balance.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_give_balance(&mut self) -> ::std::vec::Vec<u8> {
+        self.give_balance.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(5);
+        let mut fields = ::std::vec::Vec::with_capacity(7);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "order_id",
@@ -6056,11 +6400,21 @@ impl MintlayerFillOrder {
             |m: &mut MintlayerFillOrder| { &mut m.destination },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MintlayerOutputValue>(
+            "initially_asked",
+            |m: &MintlayerFillOrder| { &m.initially_asked },
+            |m: &mut MintlayerFillOrder| { &mut m.initially_asked },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MintlayerOutputValue>(
+            "initially_given",
+            |m: &MintlayerFillOrder| { &m.initially_given },
+            |m: &mut MintlayerFillOrder| { &mut m.initially_given },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "ask_balance",
             |m: &MintlayerFillOrder| { &m.ask_balance },
             |m: &mut MintlayerFillOrder| { &mut m.ask_balance },
         ));
-        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, MintlayerOutputValue>(
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "give_balance",
             |m: &MintlayerFillOrder| { &m.give_balance },
             |m: &mut MintlayerFillOrder| { &mut m.give_balance },
@@ -6086,18 +6440,24 @@ impl ::protobuf::Message for MintlayerFillOrder {
         if self.destination.is_none() {
             return false;
         }
+        if self.initially_asked.is_none() {
+            return false;
+        }
+        if self.initially_given.is_none() {
+            return false;
+        }
         if self.ask_balance.is_none() {
             return false;
         }
         if self.give_balance.is_none() {
             return false;
         }
-        for v in &self.ask_balance {
+        for v in &self.initially_asked {
             if !v.is_initialized() {
                 return false;
             }
         };
-        for v in &self.give_balance {
+        for v in &self.initially_given {
             if !v.is_initialized() {
                 return false;
             }
@@ -6118,10 +6478,16 @@ impl ::protobuf::Message for MintlayerFillOrder {
                     self.destination = ::std::option::Option::Some(is.read_string()?);
                 },
                 34 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.ask_balance)?;
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.initially_asked)?;
                 },
                 42 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.give_balance)?;
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.initially_given)?;
+                },
+                50 => {
+                    self.ask_balance = ::std::option::Option::Some(is.read_bytes()?);
+                },
+                58 => {
+                    self.give_balance = ::std::option::Option::Some(is.read_bytes()?);
                 },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
@@ -6144,13 +6510,19 @@ impl ::protobuf::Message for MintlayerFillOrder {
         if let Some(v) = self.destination.as_ref() {
             my_size += ::protobuf::rt::string_size(3, &v);
         }
-        if let Some(v) = self.ask_balance.as_ref() {
+        if let Some(v) = self.initially_asked.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
         }
-        if let Some(v) = self.give_balance.as_ref() {
+        if let Some(v) = self.initially_given.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
+        if let Some(v) = self.ask_balance.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(6, &v);
+        }
+        if let Some(v) = self.give_balance.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(7, &v);
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
@@ -6167,11 +6539,17 @@ impl ::protobuf::Message for MintlayerFillOrder {
         if let Some(v) = self.destination.as_ref() {
             os.write_string(3, v)?;
         }
-        if let Some(v) = self.ask_balance.as_ref() {
+        if let Some(v) = self.initially_asked.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(4, v, os)?;
         }
-        if let Some(v) = self.give_balance.as_ref() {
+        if let Some(v) = self.initially_given.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(5, v, os)?;
+        }
+        if let Some(v) = self.ask_balance.as_ref() {
+            os.write_bytes(6, v)?;
+        }
+        if let Some(v) = self.give_balance.as_ref() {
+            os.write_bytes(7, v)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -6193,8 +6571,10 @@ impl ::protobuf::Message for MintlayerFillOrder {
         self.order_id = ::std::option::Option::None;
         self.amount = ::std::option::Option::None;
         self.destination = ::std::option::Option::None;
-        self.ask_balance.clear();
-        self.give_balance.clear();
+        self.initially_asked.clear();
+        self.initially_given.clear();
+        self.ask_balance = ::std::option::Option::None;
+        self.give_balance = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
@@ -6203,8 +6583,10 @@ impl ::protobuf::Message for MintlayerFillOrder {
             order_id: ::std::option::Option::None,
             amount: ::std::option::Option::None,
             destination: ::std::option::Option::None,
-            ask_balance: ::protobuf::MessageField::none(),
-            give_balance: ::protobuf::MessageField::none(),
+            initially_asked: ::protobuf::MessageField::none(),
+            initially_given: ::protobuf::MessageField::none(),
+            ask_balance: ::std::option::Option::None,
+            give_balance: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -11859,52 +12241,53 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x12O\n\nchain_type\x18\x02\x20\x02(\x0e20.hw.trezor.messages.mintlayer.\
     MintlayerChainTypeR\tchainType\x12U\n\x0caddress_type\x18\x03\x20\x02(\
     \x0e22.hw.trezor.messages.mintlayer.MintlayerAddressTypeR\x0baddressType\
-    \x12\x18\n\x07message\x18\x04\x20\x02(\x0cR\x07message\"\xe3\x01\n\x0fMi\
+    \x12\x18\n\x07message\x18\x04\x20\x02(\x0cR\x07message\"\x9f\x02\n\x0fMi\
     ntlayerSignTx\x12#\n\routputs_count\x18\x01\x20\x02(\rR\x0coutputsCount\
     \x12!\n\x0cinputs_count\x18\x02\x20\x02(\rR\x0binputsCount\x12O\n\nchain\
     _type\x18\x03\x20\x02(\x0e20.hw.trezor.messages.mintlayer.MintlayerChain\
-    TypeR\tchainType\x12\x1b\n\x07version\x18\x04\x20\x01(\r:\x011R\x07versi\
-    on\x12\x1a\n\x08chunkify\x18\x05\x20\x01(\x08R\x08chunkify\"\x87\x07\n\
-    \x12MintlayerTxRequest\x12m\n\rinput_request\x18\x01\x20\x01(\x0b2H.hw.t\
-    rezor.messages.mintlayer.MintlayerTxRequest.MintlayerTxInputRequestR\x0c\
-    inputRequest\x12p\n\x0eoutput_request\x18\x02\x20\x01(\x0b2I.hw.trezor.m\
-    essages.mintlayer.MintlayerTxRequest.MintlayerTxOutputRequestR\routputRe\
-    quest\x12t\n\x10signing_finished\x18\x03\x20\x01(\x0b2I.hw.trezor.messag\
-    es.mintlayer.MintlayerTxRequest.MintlayerTxSigningResultR\x0fsigningFini\
-    shed\x1a:\n\x17MintlayerTxInputRequest\x12\x1f\n\x0binput_index\x18\x01\
-    \x20\x02(\rR\ninputIndex\x1aV\n\x18MintlayerTxOutputRequest\x12!\n\x0cou\
-    tput_index\x18\x01\x20\x02(\rR\x0boutputIndex\x12\x17\n\x07tx_hash\x18\
-    \x02\x20\x01(\x0cR\x06txHash\x1aU\n\x12MintlayerSignature\x12\x1c\n\tsig\
-    nature\x18\x01\x20\x02(\x0cR\tsignature\x12!\n\x0cmultisig_idx\x18\x02\
-    \x20\x01(\rR\x0bmultisigIdx\x1a\xa3\x01\n\x1bMintlayerSignaturesForInput\
-    \x12\x1f\n\x0binput_index\x18\x01\x20\x02(\rR\ninputIndex\x12c\n\nsignat\
-    ures\x18\x02\x20\x03(\x0b2C.hw.trezor.messages.mintlayer.MintlayerTxRequ\
-    est.MintlayerSignatureR\nsignatures\x1a\x88\x01\n\x18MintlayerTxSigningR\
-    esult\x12l\n\nsignatures\x18\x01\x20\x03(\x0b2L.hw.trezor.messages.mintl\
-    ayer.MintlayerTxRequest.MintlayerSignaturesForInputR\nsignatures\"V\n\
-    \x14MintlayerAddressPath\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08add\
-    ressN\x12!\n\x0cmultisig_idx\x18\x02\x20\x01(\rR\x0bmultisigIdx\"\xe9\
-    \x01\n\x14MintlayerUtxoTxInput\x12P\n\taddresses\x18\x01\x20\x03(\x0b22.\
-    hw.trezor.messages.mintlayer.MintlayerAddressPathR\taddresses\x12\x1b\n\
-    \tprev_hash\x18\x02\x20\x02(\x0cR\x08prevHash\x12\x1d\n\nprev_index\x18\
-    \x03\x20\x02(\rR\tprevIndex\x12C\n\x04type\x18\x04\x20\x02(\x0e2/.hw.tre\
-    zor.messages.mintlayer.MintlayerUtxoTypeR\x04type\"\xf9\x01\n\x17Mintlay\
-    erAccountTxInput\x12P\n\taddresses\x18\x01\x20\x03(\x0b22.hw.trezor.mess\
-    ages.mintlayer.MintlayerAddressPathR\taddresses\x12\x14\n\x05nonce\x18\
-    \x02\x20\x02(\x04R\x05nonce\x12v\n\x12delegation_balance\x18\x03\x20\x01\
-    (\x0b2G.hw.trezor.messages.mintlayer.MintlayerAccountSpendingDelegationB\
-    alanceR\x11delegationBalance\"h\n)MintlayerAccountSpendingDelegationBala\
-    nce\x12#\n\rdelegation_id\x18\x01\x20\x02(\tR\x0cdelegationId\x12\x16\n\
-    \x06amount\x18\x02\x20\x02(\x0cR\x06amount\"\xcf\x07\n\x1eMintlayerAccou\
-    ntCommandTxInput\x12P\n\taddresses\x18\x01\x20\x03(\x0b22.hw.trezor.mess\
-    ages.mintlayer.MintlayerAddressPathR\taddresses\x12\x14\n\x05nonce\x18\
-    \x02\x20\x02(\x04R\x05nonce\x12E\n\x04mint\x18\x03\x20\x01(\x0b21.hw.tre\
-    zor.messages.mintlayer.MintlayerMintTokensR\x04mint\x12K\n\x06unmint\x18\
-    \x04\x20\x01(\x0b23.hw.trezor.messages.mintlayer.MintlayerUnmintTokensR\
-    \x06unmint\x12b\n\x11lock_token_supply\x18\x05\x20\x01(\x0b26.hw.trezor.\
-    messages.mintlayer.MintlayerLockTokenSupplyR\x0flockTokenSupply\x12U\n\
-    \x0cfreeze_token\x18\x06\x20\x01(\x0b22.hw.trezor.messages.mintlayer.Min\
-    tlayerFreezeTokenR\x0bfreezeToken\x12[\n\x0eunfreeze_token\x18\x07\x20\
+    TypeR\tchainType\x12:\n\x19input_commitments_version\x18\x04\x20\x02(\rR\
+    \x17inputCommitmentsVersion\x12\x1b\n\x07version\x18\x05\x20\x01(\r:\x01\
+    1R\x07version\x12\x1a\n\x08chunkify\x18\x06\x20\x01(\x08R\x08chunkify\"\
+    \x87\x07\n\x12MintlayerTxRequest\x12m\n\rinput_request\x18\x01\x20\x01(\
+    \x0b2H.hw.trezor.messages.mintlayer.MintlayerTxRequest.MintlayerTxInputR\
+    equestR\x0cinputRequest\x12p\n\x0eoutput_request\x18\x02\x20\x01(\x0b2I.\
+    hw.trezor.messages.mintlayer.MintlayerTxRequest.MintlayerTxOutputRequest\
+    R\routputRequest\x12t\n\x10signing_finished\x18\x03\x20\x01(\x0b2I.hw.tr\
+    ezor.messages.mintlayer.MintlayerTxRequest.MintlayerTxSigningResultR\x0f\
+    signingFinished\x1a:\n\x17MintlayerTxInputRequest\x12\x1f\n\x0binput_ind\
+    ex\x18\x01\x20\x02(\rR\ninputIndex\x1aV\n\x18MintlayerTxOutputRequest\
+    \x12!\n\x0coutput_index\x18\x01\x20\x02(\rR\x0boutputIndex\x12\x17\n\x07\
+    tx_hash\x18\x02\x20\x01(\x0cR\x06txHash\x1aU\n\x12MintlayerSignature\x12\
+    \x1c\n\tsignature\x18\x01\x20\x02(\x0cR\tsignature\x12!\n\x0cmultisig_id\
+    x\x18\x02\x20\x01(\rR\x0bmultisigIdx\x1a\xa3\x01\n\x1bMintlayerSignature\
+    sForInput\x12\x1f\n\x0binput_index\x18\x01\x20\x02(\rR\ninputIndex\x12c\
+    \n\nsignatures\x18\x02\x20\x03(\x0b2C.hw.trezor.messages.mintlayer.Mintl\
+    ayerTxRequest.MintlayerSignatureR\nsignatures\x1a\x88\x01\n\x18Mintlayer\
+    TxSigningResult\x12l\n\nsignatures\x18\x01\x20\x03(\x0b2L.hw.trezor.mess\
+    ages.mintlayer.MintlayerTxRequest.MintlayerSignaturesForInputR\nsignatur\
+    es\"V\n\x14MintlayerAddressPath\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\
+    \x08addressN\x12!\n\x0cmultisig_idx\x18\x02\x20\x01(\rR\x0bmultisigIdx\"\
+    \xe9\x01\n\x14MintlayerUtxoTxInput\x12P\n\taddresses\x18\x01\x20\x03(\
+    \x0b22.hw.trezor.messages.mintlayer.MintlayerAddressPathR\taddresses\x12\
+    \x1b\n\tprev_hash\x18\x02\x20\x02(\x0cR\x08prevHash\x12\x1d\n\nprev_inde\
+    x\x18\x03\x20\x02(\rR\tprevIndex\x12C\n\x04type\x18\x04\x20\x02(\x0e2/.h\
+    w.trezor.messages.mintlayer.MintlayerUtxoTypeR\x04type\"\xf9\x01\n\x17Mi\
+    ntlayerAccountTxInput\x12P\n\taddresses\x18\x01\x20\x03(\x0b22.hw.trezor\
+    .messages.mintlayer.MintlayerAddressPathR\taddresses\x12\x14\n\x05nonce\
+    \x18\x02\x20\x02(\x04R\x05nonce\x12v\n\x12delegation_balance\x18\x03\x20\
+    \x01(\x0b2G.hw.trezor.messages.mintlayer.MintlayerAccountSpendingDelegat\
+    ionBalanceR\x11delegationBalance\"h\n)MintlayerAccountSpendingDelegation\
+    Balance\x12#\n\rdelegation_id\x18\x01\x20\x02(\tR\x0cdelegationId\x12\
+    \x16\n\x06amount\x18\x02\x20\x02(\x0cR\x06amount\"\xcf\x07\n\x1eMintlaye\
+    rAccountCommandTxInput\x12P\n\taddresses\x18\x01\x20\x03(\x0b22.hw.trezo\
+    r.messages.mintlayer.MintlayerAddressPathR\taddresses\x12\x14\n\x05nonce\
+    \x18\x02\x20\x02(\x04R\x05nonce\x12E\n\x04mint\x18\x03\x20\x01(\x0b21.hw\
+    .trezor.messages.mintlayer.MintlayerMintTokensR\x04mint\x12K\n\x06unmint\
+    \x18\x04\x20\x01(\x0b23.hw.trezor.messages.mintlayer.MintlayerUnmintToke\
+    nsR\x06unmint\x12b\n\x11lock_token_supply\x18\x05\x20\x01(\x0b26.hw.trez\
+    or.messages.mintlayer.MintlayerLockTokenSupplyR\x0flockTokenSupply\x12U\
+    \n\x0cfreeze_token\x18\x06\x20\x01(\x0b22.hw.trezor.messages.mintlayer.M\
+    intlayerFreezeTokenR\x0bfreezeToken\x12[\n\x0eunfreeze_token\x18\x07\x20\
     \x01(\x0b24.hw.trezor.messages.mintlayer.MintlayerUnfreezeTokenR\runfree\
     zeToken\x12q\n\x16change_token_authority\x18\x08\x20\x01(\x0b2;.hw.trezo\
     r.messages.mintlayer.MintlayerChangeTokenAuthorityR\x14changeTokenAuthor\
@@ -11926,134 +12309,140 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     .hw.trezor.messages.mintlayer.MintlayerOutputValueR\x0einitiallyAsked\
     \x12[\n\x0finitially_given\x18\x05\x20\x02(\x0b22.hw.trezor.messages.min\
     tlayer.MintlayerOutputValueR\x0einitiallyGiven\"1\n\x14MintlayerFreezeOr\
-    der\x12\x19\n\x08order_id\x18\x01\x20\x02(\tR\x07orderId\"\xec\x01\n\x18\
+    der\x12\x19\n\x08order_id\x18\x01\x20\x02(\tR\x07orderId\"\xb3\x02\n\x18\
     MintlayerConcludeOrderV1\x12\x19\n\x08order_id\x18\x01\x20\x02(\tR\x07or\
-    derId\x12^\n\x11filled_ask_amount\x18\x02\x20\x02(\x0b22.hw.trezor.messa\
-    ges.mintlayer.MintlayerOutputValueR\x0ffilledAskAmount\x12U\n\x0cgive_ba\
-    lance\x18\x03\x20\x02(\x0b22.hw.trezor.messages.mintlayer.MintlayerOutpu\
-    tValueR\x0bgiveBalance\"H\n\x13MintlayerMintTokens\x12\x19\n\x08token_id\
-    \x18\x01\x20\x02(\tR\x07tokenId\x12\x16\n\x06amount\x18\x02\x20\x02(\x0c\
-    R\x06amount\"2\n\x15MintlayerUnmintTokens\x12\x19\n\x08token_id\x18\x01\
-    \x20\x02(\tR\x07tokenId\"5\n\x18MintlayerLockTokenSupply\x12\x19\n\x08to\
-    ken_id\x18\x01\x20\x02(\tR\x07tokenId\"c\n\x14MintlayerFreezeToken\x12\
-    \x19\n\x08token_id\x18\x01\x20\x02(\tR\x07tokenId\x120\n\x14is_token_unf\
-    reezable\x18\x02\x20\x02(\x08R\x12isTokenUnfreezable\"3\n\x16MintlayerUn\
-    freezeToken\x12\x19\n\x08token_id\x18\x01\x20\x02(\tR\x07tokenId\"\\\n\
-    \x1dMintlayerChangeTokenAuthority\x12\x19\n\x08token_id\x18\x01\x20\x02(\
-    \tR\x07tokenId\x12\x20\n\x0bdestination\x18\x02\x20\x02(\tR\x0bdestinati\
-    on\"\xea\x01\n\x16MintlayerConcludeOrder\x12\x19\n\x08order_id\x18\x01\
-    \x20\x02(\tR\x07orderId\x12^\n\x11filled_ask_amount\x18\x02\x20\x02(\x0b\
-    22.hw.trezor.messages.mintlayer.MintlayerOutputValueR\x0ffilledAskAmount\
-    \x12U\n\x0cgive_balance\x18\x03\x20\x02(\x0b22.hw.trezor.messages.mintla\
-    yer.MintlayerOutputValueR\x0bgiveBalance\"\x95\x02\n\x12MintlayerFillOrd\
-    er\x12\x19\n\x08order_id\x18\x01\x20\x02(\tR\x07orderId\x12\x16\n\x06amo\
-    unt\x18\x02\x20\x02(\x0cR\x06amount\x12\x20\n\x0bdestination\x18\x03\x20\
-    \x02(\tR\x0bdestination\x12S\n\x0bask_balance\x18\x04\x20\x02(\x0b22.hw.\
-    trezor.messages.mintlayer.MintlayerOutputValueR\naskBalance\x12U\n\x0cgi\
-    ve_balance\x18\x05\x20\x02(\x0b22.hw.trezor.messages.mintlayer.Mintlayer\
-    OutputValueR\x0bgiveBalance\"_\n\x1fMintlayerChangeTokenMetadataUri\x12\
-    \x19\n\x08token_id\x18\x01\x20\x02(\tR\x07tokenId\x12!\n\x0cmetadata_uri\
-    \x18\x02\x20\x02(\x0cR\x0bmetadataUri\"\x87\x01\n\x19MintlayerTokenOutpu\
-    tValue\x12\x19\n\x08token_id\x18\x01\x20\x02(\tR\x07tokenId\x12!\n\x0cto\
-    ken_ticker\x18\x02\x20\x02(\x0cR\x0btokenTicker\x12,\n\x12number_of_deci\
-    mals\x18\x03\x20\x02(\rR\x10numberOfDecimals\"}\n\x14MintlayerOutputValu\
-    e\x12\x16\n\x06amount\x18\x01\x20\x02(\x0cR\x06amount\x12M\n\x05token\
-    \x18\x02\x20\x01(\x0b27.hw.trezor.messages.mintlayer.MintlayerTokenOutpu\
-    tValueR\x05token\"\x7f\n\x19MintlayerTransferTxOutput\x12\x18\n\x07addre\
-    ss\x18\x01\x20\x02(\tR\x07address\x12H\n\x05value\x18\x02\x20\x02(\x0b22\
-    .hw.trezor.messages.mintlayer.MintlayerOutputValueR\x05value\"\xa4\x01\n\
-    \x17MintlayerOutputTimeLock\x12!\n\x0cuntil_height\x18\x01\x20\x01(\x04R\
-    \x0buntilHeight\x12\x1d\n\nuntil_time\x18\x02\x20\x01(\x04R\tuntilTime\
-    \x12&\n\x0ffor_block_count\x18\x03\x20\x01(\x04R\rforBlockCount\x12\x1f\
-    \n\x0bfor_seconds\x18\x04\x20\x01(\x04R\nforSeconds\"\xd2\x01\n!Mintlaye\
-    rLockThenTransferTxOutput\x12\x18\n\x07address\x18\x01\x20\x02(\tR\x07ad\
-    dress\x12H\n\x05value\x18\x02\x20\x02(\x0b22.hw.trezor.messages.mintlaye\
-    r.MintlayerOutputValueR\x05value\x12I\n\x04lock\x18\x03\x20\x02(\x0b25.h\
-    w.trezor.messages.mintlayer.MintlayerOutputTimeLockR\x04lock\"a\n\x15Min\
-    tlayerBurnTxOutput\x12H\n\x05value\x18\x01\x20\x02(\x0b22.hw.trezor.mess\
-    ages.mintlayer.MintlayerOutputValueR\x05value\"\x9d\x02\n\x20MintlayerCr\
-    eateStakePoolTxOutput\x12\x17\n\x07pool_id\x18\x01\x20\x02(\tR\x06poolId\
-    \x12\x16\n\x06pledge\x18\x02\x20\x02(\x0cR\x06pledge\x12\x16\n\x06staker\
-    \x18\x03\x20\x02(\tR\x06staker\x12$\n\x0evrf_public_key\x18\x04\x20\x02(\
-    \tR\x0cvrfPublicKey\x12)\n\x10decommission_key\x18\x05\x20\x02(\tR\x0fde\
-    commissionKey\x129\n\x19margin_ratio_per_thousand\x18\x06\x20\x02(\rR\
-    \x16marginRatioPerThousand\x12$\n\x0ecost_per_block\x18\x07\x20\x02(\x0c\
-    R\x0ccostPerBlock\"\x8a\x01\n&MintlayerProduceBlockFromStakeTxOutput\x12\
-    \x20\n\x0bdestination\x18\x01\x20\x02(\tR\x0bdestination\x12\x17\n\x07po\
-    ol_id\x18\x02\x20\x02(\tR\x06poolId\x12%\n\x0estaker_balance\x18\x03\x20\
-    \x02(\x0cR\rstakerBalance\"`\n#MintlayerCreateDelegationIdTxOutput\x12\
-    \x20\n\x0bdestination\x18\x01\x20\x02(\tR\x0bdestination\x12\x17\n\x07po\
-    ol_id\x18\x02\x20\x02(\tR\x06poolId\"_\n\x20MintlayerDelegateStakingTxOu\
-    tput\x12\x16\n\x06amount\x18\x01\x20\x02(\x0cR\x06amount\x12#\n\rdelegat\
-    ion_id\x18\x02\x20\x02(\tR\x0cdelegationId\"\x8f\x01\n\x19MintlayerToken\
-    TotalSupply\x12O\n\x04type\x18\x01\x20\x02(\x0e2;.hw.trezor.messages.min\
-    tlayer.MintlayerTokenTotalSupplyTypeR\x04type\x12!\n\x0cfixed_amount\x18\
-    \x02\x20\x01(\x0cR\x0bfixedAmount\"\xb6\x02\n#MintlayerIssueFungibleToke\
-    nTxOutput\x12!\n\x0ctoken_ticker\x18\x01\x20\x02(\x0cR\x0btokenTicker\
-    \x12,\n\x12number_of_decimals\x18\x02\x20\x02(\rR\x10numberOfDecimals\
-    \x12!\n\x0cmetadata_uri\x18\x03\x20\x02(\x0cR\x0bmetadataUri\x12Z\n\x0ct\
-    otal_supply\x18\x04\x20\x02(\x0b27.hw.trezor.messages.mintlayer.Mintlaye\
-    rTokenTotalSupplyR\x0btotalSupply\x12\x1c\n\tauthority\x18\x05\x20\x02(\
-    \tR\tauthority\x12!\n\x0cis_freezable\x18\x06\x20\x02(\x08R\x0bisFreezab\
-    le\"\xcf\x02\n\x19MintlayerIssueNftTxOutput\x12\x19\n\x08token_id\x18\
-    \x01\x20\x02(\tR\x07tokenId\x12\x20\n\x0bdestination\x18\x02\x20\x02(\tR\
-    \x0bdestination\x12\x18\n\x07creator\x18\x03\x20\x01(\tR\x07creator\x12\
-    \x12\n\x04name\x18\x04\x20\x02(\x0cR\x04name\x12\x20\n\x0bdescription\
-    \x18\x05\x20\x02(\x0cR\x0bdescription\x12\x16\n\x06ticker\x18\x06\x20\
-    \x02(\x0cR\x06ticker\x12\x19\n\x08icon_uri\x18\x07\x20\x01(\x0cR\x07icon\
-    Uri\x126\n\x17additional_metadata_uri\x18\x08\x20\x01(\x0cR\x15additiona\
-    lMetadataUri\x12\x1b\n\tmedia_uri\x18\t\x20\x01(\x0cR\x08mediaUri\x12\
-    \x1d\n\nmedia_hash\x18\n\x20\x02(\x0cR\tmediaHash\"2\n\x1cMintlayerDataD\
-    epositTxOutput\x12\x12\n\x04data\x18\x01\x20\x02(\x0cR\x04data\"\x9e\x02\
-    \n\x15MintlayerHtlcTxOutput\x12H\n\x05value\x18\x01\x20\x02(\x0b22.hw.tr\
-    ezor.messages.mintlayer.MintlayerOutputValueR\x05value\x12\x1f\n\x0bsecr\
-    et_hash\x18\x02\x20\x02(\x0cR\nsecretHash\x12\x1b\n\tspend_key\x18\x03\
-    \x20\x02(\tR\x08spendKey\x12^\n\x0frefund_timelock\x18\x04\x20\x02(\x0b2\
-    5.hw.trezor.messages.mintlayer.MintlayerOutputTimeLockR\x0erefundTimeloc\
-    k\x12\x1d\n\nrefund_key\x18\x05\x20\x02(\tR\trefundKey\"\xcf\x01\n\x1cMi\
-    ntlayerCreateOrderTxOutput\x12!\n\x0cconclude_key\x18\x01\x20\x02(\tR\
-    \x0bconcludeKey\x12D\n\x03ask\x18\x02\x20\x02(\x0b22.hw.trezor.messages.\
-    mintlayer.MintlayerOutputValueR\x03ask\x12F\n\x04give\x18\x03\x20\x02(\
-    \x0b22.hw.trezor.messages.mintlayer.MintlayerOutputValueR\x04give\"\xf3\
-    \r\n\x0eMintlayerTxAck\x12S\n\x05input\x18\x01\x20\x01(\x0b2=.hw.trezor.\
-    messages.mintlayer.MintlayerTxAck.MintlayerTxInputR\x05input\x12V\n\x06o\
-    utput\x18\x02\x20\x01(\x0b2>.hw.trezor.messages.mintlayer.MintlayerTxAck\
-    .MintlayerTxOutputR\x06output\x1a\xf3\x02\n\x10MintlayerTxInput\x12F\n\
-    \x04utxo\x18\x01\x20\x01(\x0b22.hw.trezor.messages.mintlayer.MintlayerUt\
-    xoTxInputR\x04utxo\x12O\n\x07account\x18\x02\x20\x01(\x0b25.hw.trezor.me\
-    ssages.mintlayer.MintlayerAccountTxInputR\x07account\x12e\n\x0faccount_c\
-    ommand\x18\x03\x20\x01(\x0b2<.hw.trezor.messages.mintlayer.MintlayerAcco\
-    untCommandTxInputR\x0eaccountCommand\x12_\n\rorder_command\x18\x04\x20\
-    \x01(\x0b2:.hw.trezor.messages.mintlayer.MintlayerOrderCommandTxInputR\
-    \x0corderCommand\x1a\xbd\t\n\x11MintlayerTxOutput\x12S\n\x08transfer\x18\
-    \x01\x20\x01(\x0b27.hw.trezor.messages.mintlayer.MintlayerTransferTxOutp\
-    utR\x08transfer\x12m\n\x12lock_then_transfer\x18\x02\x20\x01(\x0b2?.hw.t\
-    rezor.messages.mintlayer.MintlayerLockThenTransferTxOutputR\x10lockThenT\
-    ransfer\x12G\n\x04burn\x18\x03\x20\x01(\x0b23.hw.trezor.messages.mintlay\
-    er.MintlayerBurnTxOutputR\x04burn\x12j\n\x11create_stake_pool\x18\x04\
-    \x20\x01(\x0b2>.hw.trezor.messages.mintlayer.MintlayerCreateStakePoolTxO\
-    utputR\x0fcreateStakePool\x12}\n\x18produce_block_from_stake\x18\x05\x20\
-    \x01(\x0b2D.hw.trezor.messages.mintlayer.MintlayerProduceBlockFromStakeT\
-    xOutputR\x15produceBlockFromStake\x12s\n\x14create_delegation_id\x18\x06\
-    \x20\x01(\x0b2A.hw.trezor.messages.mintlayer.MintlayerCreateDelegationId\
-    TxOutputR\x12createDelegationId\x12i\n\x10delegate_staking\x18\x07\x20\
-    \x01(\x0b2>.hw.trezor.messages.mintlayer.MintlayerDelegateStakingTxOutpu\
-    tR\x0fdelegateStaking\x12s\n\x14issue_fungible_token\x18\x08\x20\x01(\
-    \x0b2A.hw.trezor.messages.mintlayer.MintlayerIssueFungibleTokenTxOutputR\
-    \x12issueFungibleToken\x12T\n\tissue_nft\x18\t\x20\x01(\x0b27.hw.trezor.\
-    messages.mintlayer.MintlayerIssueNftTxOutputR\x08issueNft\x12]\n\x0cdata\
-    _deposit\x18\n\x20\x01(\x0b2:.hw.trezor.messages.mintlayer.MintlayerData\
-    DepositTxOutputR\x0bdataDeposit\x12G\n\x04htlc\x18\x0b\x20\x01(\x0b23.hw\
-    .trezor.messages.mintlayer.MintlayerHtlcTxOutputR\x04htlc\x12]\n\x0ccrea\
-    te_order\x18\x0c\x20\x01(\x0b2:.hw.trezor.messages.mintlayer.MintlayerCr\
-    eateOrderTxOutputR\x0bcreateOrder*G\n\x12MintlayerChainType\x12\x0b\n\
-    \x07Mainnet\x10\x01\x12\x0b\n\x07Testnet\x10\x02\x12\x0b\n\x07Regtest\
-    \x10\x03\x12\n\n\x06Signet\x10\x04*;\n\x14MintlayerAddressType\x12\x0e\n\
-    \nPUBLIC_KEY\x10\x01\x12\x13\n\x0fPUBLIC_KEY_HASH\x10\x02*/\n\x11Mintlay\
-    erUtxoType\x12\x0f\n\x0bTRANSACTION\x10\0\x12\t\n\x05BLOCK\x10\x01*G\n\
-    \x1dMintlayerTokenTotalSupplyType\x12\t\n\x05FIXED\x10\0\x12\x0c\n\x08LO\
-    CKABLE\x10\x01\x12\r\n\tUNLIMITED\x10\x02B=\n#com.satoshilabs.trezor.lib\
-    .protobufB\x16TrezorMessageMintlayer\
+    derId\x12[\n\x0finitially_asked\x18\x02\x20\x02(\x0b22.hw.trezor.message\
+    s.mintlayer.MintlayerOutputValueR\x0einitiallyAsked\x12[\n\x0finitially_\
+    given\x18\x03\x20\x02(\x0b22.hw.trezor.messages.mintlayer.MintlayerOutpu\
+    tValueR\x0einitiallyGiven\x12\x1f\n\x0bask_balance\x18\x04\x20\x02(\x0cR\
+    \naskBalance\x12!\n\x0cgive_balance\x18\x05\x20\x02(\x0cR\x0bgiveBalance\
+    \"H\n\x13MintlayerMintTokens\x12\x19\n\x08token_id\x18\x01\x20\x02(\tR\
+    \x07tokenId\x12\x16\n\x06amount\x18\x02\x20\x02(\x0cR\x06amount\"2\n\x15\
+    MintlayerUnmintTokens\x12\x19\n\x08token_id\x18\x01\x20\x02(\tR\x07token\
+    Id\"5\n\x18MintlayerLockTokenSupply\x12\x19\n\x08token_id\x18\x01\x20\
+    \x02(\tR\x07tokenId\"c\n\x14MintlayerFreezeToken\x12\x19\n\x08token_id\
+    \x18\x01\x20\x02(\tR\x07tokenId\x120\n\x14is_token_unfreezable\x18\x02\
+    \x20\x02(\x08R\x12isTokenUnfreezable\"3\n\x16MintlayerUnfreezeToken\x12\
+    \x19\n\x08token_id\x18\x01\x20\x02(\tR\x07tokenId\"\\\n\x1dMintlayerChan\
+    geTokenAuthority\x12\x19\n\x08token_id\x18\x01\x20\x02(\tR\x07tokenId\
+    \x12\x20\n\x0bdestination\x18\x02\x20\x02(\tR\x0bdestination\"\xb1\x02\n\
+    \x16MintlayerConcludeOrder\x12\x19\n\x08order_id\x18\x01\x20\x02(\tR\x07\
+    orderId\x12[\n\x0finitially_asked\x18\x02\x20\x02(\x0b22.hw.trezor.messa\
+    ges.mintlayer.MintlayerOutputValueR\x0einitiallyAsked\x12[\n\x0finitiall\
+    y_given\x18\x03\x20\x02(\x0b22.hw.trezor.messages.mintlayer.MintlayerOut\
+    putValueR\x0einitiallyGiven\x12\x1f\n\x0bask_balance\x18\x04\x20\x02(\
+    \x0cR\naskBalance\x12!\n\x0cgive_balance\x18\x05\x20\x02(\x0cR\x0bgiveBa\
+    lance\"\xe7\x02\n\x12MintlayerFillOrder\x12\x19\n\x08order_id\x18\x01\
+    \x20\x02(\tR\x07orderId\x12\x16\n\x06amount\x18\x02\x20\x02(\x0cR\x06amo\
+    unt\x12\x20\n\x0bdestination\x18\x03\x20\x02(\tR\x0bdestination\x12[\n\
+    \x0finitially_asked\x18\x04\x20\x02(\x0b22.hw.trezor.messages.mintlayer.\
+    MintlayerOutputValueR\x0einitiallyAsked\x12[\n\x0finitially_given\x18\
+    \x05\x20\x02(\x0b22.hw.trezor.messages.mintlayer.MintlayerOutputValueR\
+    \x0einitiallyGiven\x12\x1f\n\x0bask_balance\x18\x06\x20\x02(\x0cR\naskBa\
+    lance\x12!\n\x0cgive_balance\x18\x07\x20\x02(\x0cR\x0bgiveBalance\"_\n\
+    \x1fMintlayerChangeTokenMetadataUri\x12\x19\n\x08token_id\x18\x01\x20\
+    \x02(\tR\x07tokenId\x12!\n\x0cmetadata_uri\x18\x02\x20\x02(\x0cR\x0bmeta\
+    dataUri\"\x87\x01\n\x19MintlayerTokenOutputValue\x12\x19\n\x08token_id\
+    \x18\x01\x20\x02(\tR\x07tokenId\x12!\n\x0ctoken_ticker\x18\x02\x20\x02(\
+    \x0cR\x0btokenTicker\x12,\n\x12number_of_decimals\x18\x03\x20\x02(\rR\
+    \x10numberOfDecimals\"}\n\x14MintlayerOutputValue\x12\x16\n\x06amount\
+    \x18\x01\x20\x02(\x0cR\x06amount\x12M\n\x05token\x18\x02\x20\x01(\x0b27.\
+    hw.trezor.messages.mintlayer.MintlayerTokenOutputValueR\x05token\"\x7f\n\
+    \x19MintlayerTransferTxOutput\x12\x18\n\x07address\x18\x01\x20\x02(\tR\
+    \x07address\x12H\n\x05value\x18\x02\x20\x02(\x0b22.hw.trezor.messages.mi\
+    ntlayer.MintlayerOutputValueR\x05value\"\xa4\x01\n\x17MintlayerOutputTim\
+    eLock\x12!\n\x0cuntil_height\x18\x01\x20\x01(\x04R\x0buntilHeight\x12\
+    \x1d\n\nuntil_time\x18\x02\x20\x01(\x04R\tuntilTime\x12&\n\x0ffor_block_\
+    count\x18\x03\x20\x01(\x04R\rforBlockCount\x12\x1f\n\x0bfor_seconds\x18\
+    \x04\x20\x01(\x04R\nforSeconds\"\xd2\x01\n!MintlayerLockThenTransferTxOu\
+    tput\x12\x18\n\x07address\x18\x01\x20\x02(\tR\x07address\x12H\n\x05value\
+    \x18\x02\x20\x02(\x0b22.hw.trezor.messages.mintlayer.MintlayerOutputValu\
+    eR\x05value\x12I\n\x04lock\x18\x03\x20\x02(\x0b25.hw.trezor.messages.min\
+    tlayer.MintlayerOutputTimeLockR\x04lock\"a\n\x15MintlayerBurnTxOutput\
+    \x12H\n\x05value\x18\x01\x20\x02(\x0b22.hw.trezor.messages.mintlayer.Min\
+    tlayerOutputValueR\x05value\"\x9d\x02\n\x20MintlayerCreateStakePoolTxOut\
+    put\x12\x17\n\x07pool_id\x18\x01\x20\x02(\tR\x06poolId\x12\x16\n\x06pled\
+    ge\x18\x02\x20\x02(\x0cR\x06pledge\x12\x16\n\x06staker\x18\x03\x20\x02(\
+    \tR\x06staker\x12$\n\x0evrf_public_key\x18\x04\x20\x02(\tR\x0cvrfPublicK\
+    ey\x12)\n\x10decommission_key\x18\x05\x20\x02(\tR\x0fdecommissionKey\x12\
+    9\n\x19margin_ratio_per_thousand\x18\x06\x20\x02(\rR\x16marginRatioPerTh\
+    ousand\x12$\n\x0ecost_per_block\x18\x07\x20\x02(\x0cR\x0ccostPerBlock\"\
+    \x8a\x01\n&MintlayerProduceBlockFromStakeTxOutput\x12\x20\n\x0bdestinati\
+    on\x18\x01\x20\x02(\tR\x0bdestination\x12\x17\n\x07pool_id\x18\x02\x20\
+    \x02(\tR\x06poolId\x12%\n\x0estaker_balance\x18\x03\x20\x02(\x0cR\rstake\
+    rBalance\"`\n#MintlayerCreateDelegationIdTxOutput\x12\x20\n\x0bdestinati\
+    on\x18\x01\x20\x02(\tR\x0bdestination\x12\x17\n\x07pool_id\x18\x02\x20\
+    \x02(\tR\x06poolId\"_\n\x20MintlayerDelegateStakingTxOutput\x12\x16\n\
+    \x06amount\x18\x01\x20\x02(\x0cR\x06amount\x12#\n\rdelegation_id\x18\x02\
+    \x20\x02(\tR\x0cdelegationId\"\x8f\x01\n\x19MintlayerTokenTotalSupply\
+    \x12O\n\x04type\x18\x01\x20\x02(\x0e2;.hw.trezor.messages.mintlayer.Mint\
+    layerTokenTotalSupplyTypeR\x04type\x12!\n\x0cfixed_amount\x18\x02\x20\
+    \x01(\x0cR\x0bfixedAmount\"\xb6\x02\n#MintlayerIssueFungibleTokenTxOutpu\
+    t\x12!\n\x0ctoken_ticker\x18\x01\x20\x02(\x0cR\x0btokenTicker\x12,\n\x12\
+    number_of_decimals\x18\x02\x20\x02(\rR\x10numberOfDecimals\x12!\n\x0cmet\
+    adata_uri\x18\x03\x20\x02(\x0cR\x0bmetadataUri\x12Z\n\x0ctotal_supply\
+    \x18\x04\x20\x02(\x0b27.hw.trezor.messages.mintlayer.MintlayerTokenTotal\
+    SupplyR\x0btotalSupply\x12\x1c\n\tauthority\x18\x05\x20\x02(\tR\tauthori\
+    ty\x12!\n\x0cis_freezable\x18\x06\x20\x02(\x08R\x0bisFreezable\"\xcf\x02\
+    \n\x19MintlayerIssueNftTxOutput\x12\x19\n\x08token_id\x18\x01\x20\x02(\t\
+    R\x07tokenId\x12\x20\n\x0bdestination\x18\x02\x20\x02(\tR\x0bdestination\
+    \x12\x18\n\x07creator\x18\x03\x20\x01(\tR\x07creator\x12\x12\n\x04name\
+    \x18\x04\x20\x02(\x0cR\x04name\x12\x20\n\x0bdescription\x18\x05\x20\x02(\
+    \x0cR\x0bdescription\x12\x16\n\x06ticker\x18\x06\x20\x02(\x0cR\x06ticker\
+    \x12\x19\n\x08icon_uri\x18\x07\x20\x01(\x0cR\x07iconUri\x126\n\x17additi\
+    onal_metadata_uri\x18\x08\x20\x01(\x0cR\x15additionalMetadataUri\x12\x1b\
+    \n\tmedia_uri\x18\t\x20\x01(\x0cR\x08mediaUri\x12\x1d\n\nmedia_hash\x18\
+    \n\x20\x02(\x0cR\tmediaHash\"2\n\x1cMintlayerDataDepositTxOutput\x12\x12\
+    \n\x04data\x18\x01\x20\x02(\x0cR\x04data\"\x9e\x02\n\x15MintlayerHtlcTxO\
+    utput\x12H\n\x05value\x18\x01\x20\x02(\x0b22.hw.trezor.messages.mintlaye\
+    r.MintlayerOutputValueR\x05value\x12\x1f\n\x0bsecret_hash\x18\x02\x20\
+    \x02(\x0cR\nsecretHash\x12\x1b\n\tspend_key\x18\x03\x20\x02(\tR\x08spend\
+    Key\x12^\n\x0frefund_timelock\x18\x04\x20\x02(\x0b25.hw.trezor.messages.\
+    mintlayer.MintlayerOutputTimeLockR\x0erefundTimelock\x12\x1d\n\nrefund_k\
+    ey\x18\x05\x20\x02(\tR\trefundKey\"\xcf\x01\n\x1cMintlayerCreateOrderTxO\
+    utput\x12!\n\x0cconclude_key\x18\x01\x20\x02(\tR\x0bconcludeKey\x12D\n\
+    \x03ask\x18\x02\x20\x02(\x0b22.hw.trezor.messages.mintlayer.MintlayerOut\
+    putValueR\x03ask\x12F\n\x04give\x18\x03\x20\x02(\x0b22.hw.trezor.message\
+    s.mintlayer.MintlayerOutputValueR\x04give\"\xf3\r\n\x0eMintlayerTxAck\
+    \x12S\n\x05input\x18\x01\x20\x01(\x0b2=.hw.trezor.messages.mintlayer.Min\
+    tlayerTxAck.MintlayerTxInputR\x05input\x12V\n\x06output\x18\x02\x20\x01(\
+    \x0b2>.hw.trezor.messages.mintlayer.MintlayerTxAck.MintlayerTxOutputR\
+    \x06output\x1a\xf3\x02\n\x10MintlayerTxInput\x12F\n\x04utxo\x18\x01\x20\
+    \x01(\x0b22.hw.trezor.messages.mintlayer.MintlayerUtxoTxInputR\x04utxo\
+    \x12O\n\x07account\x18\x02\x20\x01(\x0b25.hw.trezor.messages.mintlayer.M\
+    intlayerAccountTxInputR\x07account\x12e\n\x0faccount_command\x18\x03\x20\
+    \x01(\x0b2<.hw.trezor.messages.mintlayer.MintlayerAccountCommandTxInputR\
+    \x0eaccountCommand\x12_\n\rorder_command\x18\x04\x20\x01(\x0b2:.hw.trezo\
+    r.messages.mintlayer.MintlayerOrderCommandTxInputR\x0corderCommand\x1a\
+    \xbd\t\n\x11MintlayerTxOutput\x12S\n\x08transfer\x18\x01\x20\x01(\x0b27.\
+    hw.trezor.messages.mintlayer.MintlayerTransferTxOutputR\x08transfer\x12m\
+    \n\x12lock_then_transfer\x18\x02\x20\x01(\x0b2?.hw.trezor.messages.mintl\
+    ayer.MintlayerLockThenTransferTxOutputR\x10lockThenTransfer\x12G\n\x04bu\
+    rn\x18\x03\x20\x01(\x0b23.hw.trezor.messages.mintlayer.MintlayerBurnTxOu\
+    tputR\x04burn\x12j\n\x11create_stake_pool\x18\x04\x20\x01(\x0b2>.hw.trez\
+    or.messages.mintlayer.MintlayerCreateStakePoolTxOutputR\x0fcreateStakePo\
+    ol\x12}\n\x18produce_block_from_stake\x18\x05\x20\x01(\x0b2D.hw.trezor.m\
+    essages.mintlayer.MintlayerProduceBlockFromStakeTxOutputR\x15produceBloc\
+    kFromStake\x12s\n\x14create_delegation_id\x18\x06\x20\x01(\x0b2A.hw.trez\
+    or.messages.mintlayer.MintlayerCreateDelegationIdTxOutputR\x12createDele\
+    gationId\x12i\n\x10delegate_staking\x18\x07\x20\x01(\x0b2>.hw.trezor.mes\
+    sages.mintlayer.MintlayerDelegateStakingTxOutputR\x0fdelegateStaking\x12\
+    s\n\x14issue_fungible_token\x18\x08\x20\x01(\x0b2A.hw.trezor.messages.mi\
+    ntlayer.MintlayerIssueFungibleTokenTxOutputR\x12issueFungibleToken\x12T\
+    \n\tissue_nft\x18\t\x20\x01(\x0b27.hw.trezor.messages.mintlayer.Mintlaye\
+    rIssueNftTxOutputR\x08issueNft\x12]\n\x0cdata_deposit\x18\n\x20\x01(\x0b\
+    2:.hw.trezor.messages.mintlayer.MintlayerDataDepositTxOutputR\x0bdataDep\
+    osit\x12G\n\x04htlc\x18\x0b\x20\x01(\x0b23.hw.trezor.messages.mintlayer.\
+    MintlayerHtlcTxOutputR\x04htlc\x12]\n\x0ccreate_order\x18\x0c\x20\x01(\
+    \x0b2:.hw.trezor.messages.mintlayer.MintlayerCreateOrderTxOutputR\x0bcre\
+    ateOrder*G\n\x12MintlayerChainType\x12\x0b\n\x07Mainnet\x10\x01\x12\x0b\
+    \n\x07Testnet\x10\x02\x12\x0b\n\x07Regtest\x10\x03\x12\n\n\x06Signet\x10\
+    \x04*;\n\x14MintlayerAddressType\x12\x0e\n\nPUBLIC_KEY\x10\x01\x12\x13\n\
+    \x0fPUBLIC_KEY_HASH\x10\x02*/\n\x11MintlayerUtxoType\x12\x0f\n\x0bTRANSA\
+    CTION\x10\0\x12\t\n\x05BLOCK\x10\x01*G\n\x1dMintlayerTokenTotalSupplyTyp\
+    e\x12\t\n\x05FIXED\x10\0\x12\x0c\n\x08LOCKABLE\x10\x01\x12\r\n\tUNLIMITE\
+    D\x10\x02B=\n#com.satoshilabs.trezor.lib.protobufB\x16TrezorMessageMintl\
+    ayer\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/tests/device_tests/mintlayer/test_sign_message.py
+++ b/tests/device_tests/mintlayer/test_sign_message.py
@@ -81,7 +81,7 @@ def test_mintlayer_sign_message_error_path(
                 client,
                 address_type=addr_type,
                 chain_type=chain_type,
-                address_n=parse_path(f"m/44h/{coin+1}h/0h/0/0"),
+                address_n=parse_path(f"m/44h/{coin + 1}h/0h/0/0"),
                 message="Message to sign".encode(),
             )
 

--- a/tests/device_tests/mintlayer/test_sign_tx.py
+++ b/tests/device_tests/mintlayer/test_sign_tx.py
@@ -16,6 +16,7 @@
 
 import itertools
 import random
+import sys
 from typing import Optional
 
 import pytest
@@ -59,9 +60,23 @@ SIGN_TX_VECTORS = [
         "mordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqacsnmg",
         "mpool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd2ew4w",
         "mvrfpk1qq7859x9n9zk9d8j3yfefr0l2vjmcsshzdm6ryz765pdmrufxmgsyh6z8a9",
+        0,
         # sigs ======================
         "0770b640bd217d130e2a654860f6ef0d2c1711871c2bc02f725da6a9c97b84863eac0483bfbb741e53f684d000c6968b628dead5f37c1c0dbb4d926e769bb7ce",
         "0bc5ace472748f2fff8afe60152558fd84f6027081a06a45c0ba621e447b1e7f7481e442849a97a63d077fbc3347badfb03a61cdf5e74120c1e5f69b01e8535a",
+    ),
+    (
+        1,
+        "mmtc1q3plqylyzrj4mdemdfs39v8zy574rnztc5zpse0x",
+        "mdelg1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqut3aj8",
+        "mmltk1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqa3r2pu",
+        "mordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqacsnmg",
+        "mpool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd2ew4w",
+        "mvrfpk1qq7859x9n9zk9d8j3yfefr0l2vjmcsshzdm6ryz765pdmrufxmgsyh6z8a9",
+        1,
+        # sigs ======================
+        "c1d6188af3555e8a1b0215f45947258ab52bee1570fe87c22605244b1bf050a28ce6e73ef9fed75ab65ba7bfcbe32d60469f0a13dfb33a5e3dc742c2a5a31625",
+        "e8aac202adfd00d0306bb249b47cf21f3a8941347f8e4509ad69331537384716bf0e947e3d52bc1aa9e3f6a1e5969371409ecdfb892596f09c6befe46d55269e",
     ),
     (
         2,
@@ -71,6 +86,33 @@ SIGN_TX_VECTORS = [
         "tordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqj0xv66",
         "tpool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqza035u",
         "tvrfpk1qregu4v895mchautf84u46nsf9xel2507a37ksaf3stmuw44y3m4vffs89t",
+        0,
+        # sigs ======================
+        "7ae7291601bd4a6a0069d91f2695b1a37faa4d42485e9cae047f3d080253d1fa827a4c2e38e004a2199adba7b0201a243856a9a3cf1c069ec856964570635ea2",
+        "abadf0c5f984c6b1f55a32a05cc7aa37aa5aae6b0b96544bb752c01ad8a29e7d9fe90124776699228f1843b1e033e5f27b081643b0c873e776e1142845aaa56c",
+    ),
+    (
+        2,
+        "tmtc1qjn5ls4sz90ppcart66jf0vx0n0u8ndjluz8lpsy",
+        "tdelg1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnu8zn4",
+        "tmltk1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqjx44qw",
+        "tordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqj0xv66",
+        "tpool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqza035u",
+        "tvrfpk1qregu4v895mchautf84u46nsf9xel2507a37ksaf3stmuw44y3m4vffs89t",
+        1,
+        # sigs ======================
+        "f5674b6f71edfa2ed7c7b8b3a36fc7123e73f84df10dae28f78e81b3c74fc3aab6b641cba96b180116b79f931ebf9a6fea5d2b5c1596ce1ca22da430c97e58a6",
+        "0414bb46f04a85abd40f6f4e36638fc382b3eb52c8594510af6c1b4d01099ec259766e954dd9547e738886d4dd1619fbd18660f603f461baef3a9d2603ae0ebf",
+    ),
+    (
+        3,
+        "rmtc1qjn5ls4sz90ppcart66jf0vx0n0u8ndjluu6nzuv",
+        "rdelg1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqf9m6ka",
+        "rmltk1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqglfd9x",
+        "rordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgk65lj",
+        "rpool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqcynf35",
+        "rvrfpk1qregu4v895mchautf84u46nsf9xel2507a37ksaf3stmuw44y3m4vc2kzme",
+        0,
         # sigs ======================
         "7ae7291601bd4a6a0069d91f2695b1a37faa4d42485e9cae047f3d080253d1fa827a4c2e38e004a2199adba7b0201a243856a9a3cf1c069ec856964570635ea2",
         "abadf0c5f984c6b1f55a32a05cc7aa37aa5aae6b0b96544bb752c01ad8a29e7d9fe90124776699228f1843b1e033e5f27b081643b0c873e776e1142845aaa56c",
@@ -83,6 +125,20 @@ SIGN_TX_VECTORS = [
         "rordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgk65lj",
         "rpool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqcynf35",
         "rvrfpk1qregu4v895mchautf84u46nsf9xel2507a37ksaf3stmuw44y3m4vc2kzme",
+        1,
+        # sigs ======================
+        "f5674b6f71edfa2ed7c7b8b3a36fc7123e73f84df10dae28f78e81b3c74fc3aab6b641cba96b180116b79f931ebf9a6fea5d2b5c1596ce1ca22da430c97e58a6",
+        "0414bb46f04a85abd40f6f4e36638fc382b3eb52c8594510af6c1b4d01099ec259766e954dd9547e738886d4dd1619fbd18660f603f461baef3a9d2603ae0ebf",
+    ),
+    (
+        4,
+        "smtc1qjn5ls4sz90ppcart66jf0vx0n0u8ndjluet3k7h",
+        "sdelg1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq4dx7rx",
+        "smltk1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5h5fsa",
+        "sordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq578s2f",
+        "spool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqyvwdy0",
+        "svrfpk1qregu4v895mchautf84u46nsf9xel2507a37ksaf3stmuw44y3m4vt7hh77",
+        0,
         # sigs ======================
         "7ae7291601bd4a6a0069d91f2695b1a37faa4d42485e9cae047f3d080253d1fa827a4c2e38e004a2199adba7b0201a243856a9a3cf1c069ec856964570635ea2",
         "abadf0c5f984c6b1f55a32a05cc7aa37aa5aae6b0b96544bb752c01ad8a29e7d9fe90124776699228f1843b1e033e5f27b081643b0c873e776e1142845aaa56c",
@@ -95,9 +151,10 @@ SIGN_TX_VECTORS = [
         "sordr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq578s2f",
         "spool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqyvwdy0",
         "svrfpk1qregu4v895mchautf84u46nsf9xel2507a37ksaf3stmuw44y3m4vt7hh77",
+        1,
         # sigs ======================
-        "7ae7291601bd4a6a0069d91f2695b1a37faa4d42485e9cae047f3d080253d1fa827a4c2e38e004a2199adba7b0201a243856a9a3cf1c069ec856964570635ea2",
-        "abadf0c5f984c6b1f55a32a05cc7aa37aa5aae6b0b96544bb752c01ad8a29e7d9fe90124776699228f1843b1e033e5f27b081643b0c873e776e1142845aaa56c",
+        "f5674b6f71edfa2ed7c7b8b3a36fc7123e73f84df10dae28f78e81b3c74fc3aab6b641cba96b180116b79f931ebf9a6fea5d2b5c1596ce1ca22da430c97e58a6",
+        "0414bb46f04a85abd40f6f4e36638fc382b3eb52c8594510af6c1b4d01099ec259766e954dd9547e738886d4dd1619fbd18660f603f461baef3a9d2603ae0ebf",
     ),
 ]
 
@@ -110,7 +167,7 @@ CHAIN_TYPE_TO_COIN = {1: 19788, 2: 1, 3: 1, 4: 1}
     mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 )
 @pytest.mark.parametrize(
-    "chain_type, multisig_addr, delegation_id, token_id, order_id, pool_id, vrf_public_key, sig1, sig2",
+    "chain_type, multisig_addr, delegation_id, token_id, order_id, pool_id, vrf_public_key, input_commitments_version, sig1, sig2",
     SIGN_TX_VECTORS,
 )
 def test_mintlayer_sign_tx(
@@ -122,6 +179,7 @@ def test_mintlayer_sign_tx(
     order_id: str,
     pool_id: str,
     vrf_public_key: str,
+    input_commitments_version: int,
     sig1: str,
     sig2: str,
 ):
@@ -163,8 +221,6 @@ def test_mintlayer_sign_tx(
                 number_of_decimals=number_of_decimals,
             ),
         )
-        amount_0 = (0).to_bytes(16, byteorder="big")
-        value_0 = messages.MintlayerOutputValue(amount=amount_0)
 
         inputs = [
             # UTXO input
@@ -176,7 +232,7 @@ def test_mintlayer_sign_tx(
                     type=messages.MintlayerUtxoType.TRANSACTION,
                 )
             ),
-            # UTXO input wiht tokens
+            # UTXO input with tokens
             messages.MintlayerTxInput(
                 utxo=messages.MintlayerUtxoTxInput(
                     prev_hash=prev_hash,
@@ -194,7 +250,7 @@ def test_mintlayer_sign_tx(
                     type=messages.MintlayerUtxoType.TRANSACTION,
                 )
             ),
-            # Account inpput
+            # Account input
             messages.MintlayerTxInput(
                 account=messages.MintlayerAccountTxInput(
                     addresses=[address_0],
@@ -262,8 +318,10 @@ def test_mintlayer_sign_tx(
                     nonce=0,
                     conclude_order=messages.MintlayerConcludeOrder(
                         order_id=order_id,
-                        filled_ask_amount=value_0,
-                        give_balance=value_1,
+                        initially_asked=value_1,
+                        initially_given=value_1,
+                        ask_balance=amount_1,
+                        give_balance=amount_1,
                     ),
                 )
             ),
@@ -274,9 +332,11 @@ def test_mintlayer_sign_tx(
                     fill_order=messages.MintlayerFillOrder(
                         order_id=order_id,
                         amount=amount_1,
+                        initially_asked=value_1,
+                        initially_given=value_1,
                         destination=anyone_can_spend,
-                        ask_balance=value_1,
-                        give_balance=value_1,
+                        ask_balance=amount_1,
+                        give_balance=amount_1,
                     ),
                 )
             ),
@@ -499,7 +559,9 @@ def test_mintlayer_sign_tx(
             ]
         )
 
-        results = mintlayer.sign_tx(client, chain_type, inputs, outputs, prev_txs)
+        results = mintlayer.sign_tx(
+            client, chain_type, inputs, outputs, prev_txs, input_commitments_version
+        )
 
         expected_multi_sigs = {
             0: sig1,
@@ -523,34 +585,37 @@ def test_mintlayer_sign_tx(
     mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 )
 def test_mintlayer_random_sign_tx(client: Client):
+    rng = make_rng()
+
     with client:
-        num_inputs = random.randint(1, 10)
+        num_inputs = rng.randint(1, 10)
+        input_commitments_version = rng.randint(0, 1)
 
         prev_txs = {}
         inputs = []
         input_utxos = []
         total_inputs = 0
         for _ in range(num_inputs):
-            random_address = random.randint(0, 100)
-            random_account = random.randint(0, 100)
-            random_purpose = random.choice([0, 1])
+            random_address = rng.randint(0, 100)
+            random_account = rng.randint(0, 100)
+            random_purpose = rng.choice([0, 1])
             path = parse_path(
                 f"m/44h/19788h/{random_account}h/{random_purpose}/{random_address}"
             )
 
-            prev_hash = bytes(random.getrandbits(8) for _ in range(32))
+            prev_hash = bytes(rng.getrandbits(8) for _ in range(32))
 
-            random_amount = random.randint(1, 10_000)
+            random_amount = rng.randint(1, 10_000)
             total_inputs += random_amount
             address = messages.MintlayerAddressPath(address_n=path)
 
-            prev_utxo_index = random.randint(0, 100)
+            prev_utxo_index = rng.randint(0, 100)
             inp = messages.MintlayerTxInput(
                 utxo=messages.MintlayerUtxoTxInput(
                     prev_hash=prev_hash,
                     prev_index=prev_utxo_index,
                     addresses=[address],
-                    type=random.choice(list(messages.MintlayerUtxoType)),
+                    type=rng.choice(list(messages.MintlayerUtxoType)),
                 )
             )
 
@@ -569,10 +634,10 @@ def test_mintlayer_random_sign_tx(client: Client):
             inputs.append(inp)
             input_utxos.append((prev_hash, prev_utxo_index))
 
-        num_outputs = random.randint(1, 10)
+        num_outputs = rng.randint(1, 10)
         outputs = []
         for _ in range(num_outputs):
-            random_amount = random.randint(0, total_inputs // num_outputs)
+            random_amount = rng.randint(0, total_inputs // num_outputs)
             value = messages.MintlayerOutputValue(
                 amount=random_amount.to_bytes(16, byteorder="big")
             )
@@ -619,7 +684,9 @@ def test_mintlayer_random_sign_tx(client: Client):
             )
         )
 
-        result = mintlayer.sign_tx(client, 3, inputs, outputs, prev_txs)
+        result = mintlayer.sign_tx(
+            client, 3, inputs, outputs, prev_txs, input_commitments_version
+        )
 
         assert len(result) == num_inputs
 
@@ -636,9 +703,12 @@ CHAIN_TYPES = [1, 2, 3, 4]
 def test_mintlayer_sign_tx_forbidden_path(client: Client, chain_type: int):
     coin = CHAIN_TYPE_TO_COIN[chain_type]
 
-    prev_hash = bytes(random.getrandbits(8) for _ in range(32))
-    random_amount = random.randint(1, 10_000)
-    prev_utxo_index = random.randint(0, 100)
+    rng = make_rng()
+
+    input_commitments_version = rng.randint(0, 1)
+    prev_hash = bytes(rng.getrandbits(8) for _ in range(32))
+    random_amount = rng.randint(1, 10_000)
+    prev_utxo_index = rng.randint(0, 100)
 
     value = messages.MintlayerOutputValue(
         amount=random_amount.to_bytes(16, byteorder="big")
@@ -667,7 +737,7 @@ def test_mintlayer_sign_tx_forbidden_path(client: Client, chain_type: int):
                     prev_hash=prev_hash,
                     prev_index=prev_utxo_index,
                     addresses=[address],
-                    type=random.choice(list(messages.MintlayerUtxoType)),
+                    type=rng.choice(list(messages.MintlayerUtxoType)),
                 )
             )
             mintlayer.sign_tx(client, chain_type, [inp], [], prev_txs)
@@ -682,7 +752,7 @@ def test_mintlayer_sign_tx_forbidden_path(client: Client, chain_type: int):
                     prev_hash=prev_hash,
                     prev_index=prev_utxo_index,
                     addresses=[address],
-                    type=random.choice(list(messages.MintlayerUtxoType)),
+                    type=rng.choice(list(messages.MintlayerUtxoType)),
                 )
             )
             mintlayer.sign_tx(client, chain_type, [inp], [], prev_txs)
@@ -697,7 +767,7 @@ def test_mintlayer_sign_tx_forbidden_path(client: Client, chain_type: int):
                     prev_hash=prev_hash,
                     prev_index=prev_utxo_index,
                     addresses=[address],
-                    type=random.choice(list(messages.MintlayerUtxoType)),
+                    type=rng.choice(list(messages.MintlayerUtxoType)),
                 )
             )
             mintlayer.sign_tx(client, chain_type, [inp], [], prev_txs)
@@ -712,7 +782,15 @@ def test_mintlayer_sign_tx_forbidden_path(client: Client, chain_type: int):
                     prev_hash=prev_hash,
                     prev_index=prev_utxo_index,
                     addresses=[address],
-                    type=random.choice(list(messages.MintlayerUtxoType)),
+                    type=rng.choice(list(messages.MintlayerUtxoType)),
                 )
             )
-            mintlayer.sign_tx(client, chain_type, [inp], [], prev_txs)
+            mintlayer.sign_tx(
+                client, chain_type, [inp], [], prev_txs, input_commitments_version
+            )
+
+
+def make_rng() -> random.Random:
+    seed = random.randint(0, sys.maxsize)
+    print(f"Using rng seed {seed}")
+    return random.Random(seed)


### PR DESCRIPTION
The corresponding core repo PR is https://github.com/mintlayer/mintlayer-core/pull/1910

P.S. I also changed a bit how token amounts are dislpayed, it's now `"{amount_int} atoms (presumable decimal amount: {decimal_amount_str}) of unknown token with ID {token.token_id} and ticker {ticker}"` (i.e. it emphasizes that the decimal amount cannot be trusted).