### PR TITLE
Allow ProduceBlockFromStake utxos

### DIFF
--- a/core/src/apps/mintlayer/sign_tx/helpers.py
+++ b/core/src/apps/mintlayer/sign_tx/helpers.py
@@ -206,7 +206,7 @@ def _sanitize_tx_output(txo: MintlayerTxOutput | None) -> MintlayerTxOutput:
     elif txo.create_stake_pool:
         pass
     elif txo.produce_block_from_stake:
-        raise DataError("Cannot create a ProduceBlockFromStake output in a transaction")
+        pass
     elif txo.create_delegation_id:
         pass
     elif txo.delegate_staking:


### PR DESCRIPTION
Currently `_sanitize_tx_output` raises an exception on `ProduceBlockFromStake` tx outputs, on the assumption that such outputs are useless, but the function is called for UTXOs too, preventing us from signing `ProduceBlockFromStake` inputs.
In general, I don't see why we should prohibit `ProduceBlockFromStake` even if it's in the outputs, so I've just removed the `raise` statement.

P.S. the newly added test in https://github.com/mintlayer/mintlayer-core/pull/1931 fails without this fix.