### PR TITLE
Update nix version on ci

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -13,8 +13,8 @@ runs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Dependencies nixpkgs
-      run: nix-shell --arg fullDeps "${{ inputs.full-deps }}" --run "true"
+      run: timeout -v --kill-after=10 500 nix-shell --arg fullDeps "${{ inputs.full-deps }}" --run "true"
       shell: sh
     - name: Dependencies poetry
-      run: nix-shell --arg fullDeps "${{ inputs.full-deps }}" --run "poetry install"
+      run: timeout -v --kill-after=10 100 nix-shell --arg fullDeps "${{ inputs.full-deps }}" --run "poetry install"
       shell: sh

--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Install nix
-      uses: cachix/install-nix-action@v23
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Dependencies nixpkgs

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -26,10 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@v23
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --run "poetry install"
+      - uses: ./.github/actions/environment
       - run: cp -r crypto crypto_noasan
       - run: nix-shell --run "poetry run make -C crypto"
       - run: nix-shell --run "export ADDRESS_SANITIZER=0; poetry run make -C crypto_noasan"
@@ -56,10 +53,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@v23
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --run "poetry install"
+      - uses: ./.github/actions/environment
       - uses: actions/download-artifact@v4
         with:
           name: crypto-build
@@ -81,10 +75,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@v23
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --run "poetry install"
+      - uses: ./.github/actions/environment
       # LD_LIBRARY_PATH workaround: https://discourse.nixos.org/t/nixpkgs-nixos-unstable-many-package-fail-with-glibc-2-38-not-found/35078 https://github.com/NixOS/nixpkgs/issues/287764
       - run: nix-shell --arg fullDeps true --run "unset LD_LIBRARY_PATH && cd python && poetry run tox"
 
@@ -95,10 +86,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@v23
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --run "poetry install"
+      - uses: ./.github/actions/environment
       - run: nix-shell --run "poetry run make python_support_check"
 
   storage_test:
@@ -109,10 +97,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@v23
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --run "poetry install"
+      - uses: ./.github/actions/environment
       - run: unset PYTEST_TIMEOUT
       - run: nix-shell --run "poetry run make -C storage/tests build"
       - run: nix-shell --run "poetry run make -C storage/tests tests_all"

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -636,10 +636,9 @@ jobs:
           name: core-emu-${{ matrix.model }}-universal-debuglink-${{ matrix.asan }}
           path: core/build
       - run: chmod +x core/build/unix/trezor-emu-core*
-      - uses: cachix/install-nix-action@v23
+      - uses: ./.github/actions/environment
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell --arg fullDeps true --run "poetry install"
+          full-deps: true
       - run: nix-shell --arg fullDeps true --run "poetry run make -C core test_emu_monero"
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Running `nix-shell` currently fails on CI demanding Nix v2.18, while the currently used GitHub action `cachix/install-nix-action@v23` only installs Nix v2.17.

So I've cherry-picked a few commits from upstream:
1) The one where they update to `cachix/install-nix-action@v31`.
2) An earlier commit with GitHub workflows cleanup, so that `cachix/install-nix-action` is only mentioned in one place.
I also picked up a commit where they specify a timeout when installing `nixpkgs` and `poetry` (just in case and because it was a part of the same PR as the cleanup).

The upstream PRs in question are:
https://www.github.com/trezor/trezor-firmware/pull/5446
https://www.github.com/trezor/trezor-firmware/pull/5556