### PR TITLE
Fix fuzzers job on ci

### DIFF
--- a/crypto/chacha20poly1305/chacha_merged.c
+++ b/crypto/chacha20poly1305/chacha_merged.c
@@ -23,8 +23,8 @@ void ECRYPT_init(void)
   return;
 }
 
-static const char sigma[16] = "expand 32-byte k";
-static const char tau[16] = "expand 16-byte k";
+static const char sigma[] = {'e', 'x', 'p', 'a', 'n', 'd', ' ', '3', '2', '-', 'b', 'y', 't', 'e', ' ', 'k'};
+static const char tau[] = {'e', 'x', 'p', 'a', 'n', 'd', ' ', '1', '6', '-', 'b', 'y', 't', 'e', ' ', 'k'};
 
 void ECRYPT_keysetup(ECRYPT_ctx *x,const u8 *k,u32 kbits,u32 ivbits)
 {


### PR DESCRIPTION
Currently the ClusterFuzzLite job on CI fails at the build step like this - https://github.com/mintlayer/mintlayer-trezor-firmware/actions/runs/18757623134/job/53513583682

This was fixed in upstream in [this PR](https://www.github.com/trezor/trezor-firmware/pull/5734), so I cherry-picked the corresponding commits.