### PR TITLE
Specify MIT license for mintlayer-firmware-deps

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,12 +4,14 @@ This is a monorepo and different parts of monorepo are licensed
 under different licenses:
 
 * `common` - [LGPLv3](common/COPYING)
-* `core` - [GPLv3](core/COPYING)
+* `core` - mostly<sup>0</sup> [GPLv3](core/COPYING)
 * `crypto` - mostly<sup>1</sup> [MIT](crypto/LICENSE)
 * `legacy` - [LGPLv3](legacy/COPYING)
 * `python` - [LGPLv3](python/COPYING)
 * `storage` - [GPLv3](storage/COPYING)
 * all other files - [GPLv3](COPYING)
+
+<sup>0</sup> `mintlayer-firmware-deps` has the MIT license.
 
 <sup>1</sup> some files have individual licensing,
 check the file headers for more information

--- a/core/embed/rust/src/mintlayer/deps/LICENSE
+++ b/core/embed/rust/src/mintlayer/deps/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2025 RBB S.r.l
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/core/embed/rust/src/mintlayer/deps/src/lib.rs
+++ b/core/embed/rust/src/mintlayer/deps/src/lib.rs
@@ -1,3 +1,18 @@
+// Copyright (c) 2021-2025 RBB S.r.l
+// opensource@mintlayer.org
+// SPDX-License-Identifier: MIT
+// Licensed under the MIT License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://github.com/mintlayer/mintlayer-trezor-firmware/tree/mintlayer-master/core/embed/rust/src/mintlayer/deps/LICENSE
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_std]
 
 // The purpose of this crate is to allow `mintlayer-core` to check that the version of


### PR DESCRIPTION
`mintlayer-firmware-deps`, which re-exports stuff from `mintlayer-core-primitives`, is located inside the actual "firmware" part of the firmware repo, which is licensed under GPL (unlike e.g. `trezor-client`, which is licensed under Creative Commons). I'm not an expert on licensing, but IMO without an explicit license this could mean that `mintlayer-firmware-deps` is itself GPL, even though it doesn't really contain any code except for re-exports. And since it's re-exported by `trezor-client` again, which is in turn used by Mintlayer Core, the latter may technically get a GPL dependency. And GPL is not among licenses that we currently allow for dependencies in Mintlayer Core.